### PR TITLE
feat: Referral Intelligence Engine

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -93,3 +93,67 @@ analysis:
     scale: 3
 
   # pptx_template: templates/ics_template.pptx
+
+# Referral intelligence pipeline settings
+referral:
+  data_file: data/1776_ics_detailed_referral_v9_PTD.xls
+  client_id: "1776"
+  client_name: "Sample Credit Union"
+  output_dir: output/referral/
+  header_row: 0
+
+  # Influence scoring weights (must sum to 1.0)
+  scoring_weights:
+    unique_accounts: 0.35
+    burst_count: 0.25
+    channels_used: 0.20
+    velocity: 0.10
+    longevity: 0.10
+
+  # Staff multiplier weights (must sum to 1.0)
+  staff_weights:
+    avg_referrer_score: 0.60
+    unique_referrers: 0.40
+
+  # Thresholds
+  burst_window_days: 14
+  dormancy_days: 180
+  high_value_min_referrals: 5
+  emerging_min_burst_count: 2
+  emerging_lookback_days: 180
+  top_n_referrers: 25
+
+  # Entity normalization aliases (merge misspellings/variants)
+  # name_aliases:
+  #   "JOHN SMYTH": "JOHN SMITH"
+  #   "J SMITH": "JOHN SMITH"
+
+  # Branch label mapping
+  # branch_mapping:
+  #   "001": "Main Office"
+  #   "002": "North Branch"
+
+  # Referral code prefix -> channel classification
+  code_prefix_map:
+    "150A": "BRANCH_STANDARD"
+    "120A": "BRANCH_STANDARD"
+    "080A": "BRANCH_STANDARD"
+    "100A": "BRANCH_STANDARD"
+    "030A": "BRANCH_STANDARD"
+    "020A": "BRANCH_STANDARD"
+    "PC": "DIGITAL_PROCESS"
+    "EMAIL": "EMAIL"
+
+  outputs:
+    excel: true
+    powerpoint: true
+    html_charts: false
+
+  charts:
+    theme: plotly_white
+    colors: ["#1B365D", "#4A90D9", "#7BC67E", "#F5A623", "#D0021B", "#8B572A"]
+    width: 900
+    height: 500
+    scale: 3
+
+  # pptx_template: templates/referral_template.pptx

--- a/ics_toolkit/__init__.py
+++ b/ics_toolkit/__init__.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Callable
 if TYPE_CHECKING:
     from ics_toolkit.analysis.pipeline import AnalysisPipelineResult
     from ics_toolkit.append.pipeline import PipelineResult
+    from ics_toolkit.referral.pipeline import ReferralPipelineResult
 
 __version__ = "1.0.0"
 
@@ -58,5 +59,28 @@ def run_analysis(
 
     settings = Settings.for_analysis(data_file=Path(data_file), **kwargs)
     result = run_pipeline(settings.analysis, on_progress=on_progress)
+    export_outputs(result)
+    return result
+
+
+def run_referral(
+    data_file: str | Path,
+    output_dir: str | Path = "output/referral/",
+    client_id: str | None = None,
+    client_name: str | None = None,
+    on_progress: Callable[[int, int, str], None] | None = None,
+) -> "ReferralPipelineResult":
+    """Convenience function for referral pipeline (Jupyter/REPL)."""
+    from ics_toolkit.referral.pipeline import export_outputs, run_pipeline
+    from ics_toolkit.settings import Settings
+
+    kwargs: dict = {"output_dir": Path(output_dir)}
+    if client_id is not None:
+        kwargs["client_id"] = client_id
+    if client_name is not None:
+        kwargs["client_name"] = client_name
+
+    settings = Settings.for_referral(data_file=Path(data_file), **kwargs)
+    result = run_pipeline(settings.referral, on_progress=on_progress)
     export_outputs(result)
     return result

--- a/ics_toolkit/referral/__init__.py
+++ b/ics_toolkit/referral/__init__.py
@@ -1,0 +1,37 @@
+"""Referral Intelligence Engine.
+
+Influence scoring, network inference, and staff multiplier reports.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable
+
+if TYPE_CHECKING:
+    from ics_toolkit.referral.pipeline import ReferralPipelineResult
+
+__all__ = ["run_referral"]
+
+
+def run_referral(
+    data_file: str | Path,
+    output_dir: str | Path = "output/referral/",
+    client_id: str | None = None,
+    client_name: str | None = None,
+    on_progress: Callable[[int, int, str], None] | None = None,
+) -> "ReferralPipelineResult":
+    """Convenience function for referral pipeline (Jupyter/REPL)."""
+    from ics_toolkit.referral.pipeline import export_outputs, run_pipeline
+    from ics_toolkit.settings import Settings
+
+    kwargs: dict = {"output_dir": Path(output_dir)}
+    if client_id is not None:
+        kwargs["client_id"] = client_id
+    if client_name is not None:
+        kwargs["client_name"] = client_name
+
+    settings = Settings.for_referral(data_file=Path(data_file), **kwargs)
+    result = run_pipeline(settings.referral, on_progress=on_progress)
+    export_outputs(result)
+    return result

--- a/ics_toolkit/referral/analyses/__init__.py
+++ b/ics_toolkit/referral/analyses/__init__.py
@@ -1,0 +1,85 @@
+"""Referral analysis artifacts registry and orchestration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable
+
+import pandas as pd
+
+from ics_toolkit.analysis.analyses.base import AnalysisResult
+from ics_toolkit.referral.analyses.base import ReferralContext
+from ics_toolkit.referral.analyses.branch_density import analyze_branch_density
+from ics_toolkit.referral.analyses.code_health import analyze_code_health
+from ics_toolkit.referral.analyses.dormant_referrers import analyze_dormant_referrers
+from ics_toolkit.referral.analyses.emerging_referrers import analyze_emerging_referrers
+from ics_toolkit.referral.analyses.onetime_vs_repeat import analyze_onetime_vs_repeat
+from ics_toolkit.referral.analyses.overview import analyze_overview
+from ics_toolkit.referral.analyses.staff_multipliers import analyze_staff_multipliers
+from ics_toolkit.referral.analyses.top_referrers import analyze_top_referrers
+
+logger = logging.getLogger(__name__)
+
+# Ordered list of (name, function) for all referral analyses.
+# Each function has signature: (ctx: ReferralContext) -> AnalysisResult
+REFERRAL_ANALYSIS_REGISTRY: list[tuple[str, Callable]] = [
+    ("Top Referrers", analyze_top_referrers),
+    ("Emerging Referrers", analyze_emerging_referrers),
+    ("Dormant High-Value Referrers", analyze_dormant_referrers),
+    ("One-time vs Repeat Referrers", analyze_onetime_vs_repeat),
+    ("Staff Multipliers", analyze_staff_multipliers),
+    ("Branch Influence Density", analyze_branch_density),
+    ("Code Health Report", analyze_code_health),
+]
+
+# Overview is run separately after all other analyses (receives prior_results).
+OVERVIEW_ANALYSIS = ("Overview KPIs", analyze_overview)
+
+
+def run_all_referral_analyses(
+    ctx: ReferralContext,
+    on_progress: Callable | None = None,
+) -> list[AnalysisResult]:
+    """Run all registered referral analyses and return results."""
+    results: list[AnalysisResult] = []
+    total = len(REFERRAL_ANALYSIS_REGISTRY)
+
+    for i, (name, func) in enumerate(REFERRAL_ANALYSIS_REGISTRY):
+        if on_progress:
+            on_progress(i, total, name)
+
+        try:
+            result = func(ctx)
+            results.append(result)
+            logger.info("  [%d/%d] %s", i + 1, total, name)
+        except Exception as e:
+            logger.warning("  [%d/%d] %s FAILED: %s", i + 1, total, name, e)
+            results.append(
+                AnalysisResult(
+                    name=name,
+                    title=name,
+                    df=pd.DataFrame(),
+                    error=str(e),
+                )
+            )
+
+    # Run overview last with prior results
+    name, func = OVERVIEW_ANALYSIS
+    if on_progress:
+        on_progress(total, total + 1, name)
+    try:
+        result = func(ctx, prior_results=results)
+        results.append(result)
+        logger.info("  [%d/%d] %s", total + 1, total + 1, name)
+    except Exception as e:
+        logger.warning("  [%d/%d] %s FAILED: %s", total + 1, total + 1, name, e)
+        results.append(
+            AnalysisResult(
+                name=name,
+                title=name,
+                df=pd.DataFrame(),
+                error=str(e),
+            )
+        )
+
+    return results

--- a/ics_toolkit/referral/analyses/base.py
+++ b/ics_toolkit/referral/analyses/base.py
@@ -1,0 +1,21 @@
+"""Base infrastructure for referral analysis artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+if TYPE_CHECKING:
+    from ics_toolkit.settings import ReferralSettings
+
+
+@dataclass
+class ReferralContext:
+    """Bundles all pre-computed data for referral analysis functions."""
+
+    df: pd.DataFrame
+    referrer_metrics: pd.DataFrame
+    staff_metrics: pd.DataFrame
+    settings: "ReferralSettings"

--- a/ics_toolkit/referral/analyses/branch_density.py
+++ b/ics_toolkit/referral/analyses/branch_density.py
@@ -1,0 +1,64 @@
+"""R06: Branch-level Influence Density."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from ics_toolkit.analysis.analyses.base import AnalysisResult, safe_percentage
+from ics_toolkit.referral.analyses.base import ReferralContext
+
+
+def analyze_branch_density(ctx: ReferralContext) -> AnalysisResult:
+    """Compute avg influence score of referrers routed through each branch.
+
+    This measures referrer quality per branch, NOT branch production volume.
+    """
+    name = "Branch Influence Density"
+    df = ctx.df.copy()
+    m = ctx.referrer_metrics
+
+    if df.empty or m.empty:
+        return AnalysisResult(name=name, title=name, df=pd.DataFrame(), sheet_name="R06_Branch")
+
+    # Exclude unknown branches
+    df = df[df["Branch Code"] != "UNKNOWN"].copy()
+
+    influence_lookup = m.set_index("Referrer")["Influence Score"]
+    df["_referrer_score"] = df["Referrer"].map(influence_lookup).fillna(0)
+
+    branch = (
+        df.groupby("Branch Code")
+        .agg(
+            **{"Total Referrals": ("MRDB Account Hash", "count")},
+            **{"Unique Referrers": ("Referrer", "nunique")},
+            **{"Avg Influence Score": ("_referrer_score", "mean")},
+        )
+        .reset_index()
+    )
+    branch.rename(columns={"Branch Code": "Branch"}, inplace=True)
+    branch["Avg Influence Score"] = branch["Avg Influence Score"].round(1)
+
+    # Add top referrer per branch
+    top_by_branch = (
+        df.sort_values("_referrer_score", ascending=False)
+        .drop_duplicates(subset=["Branch Code"])[["Branch Code", "Referrer"]]
+        .rename(columns={"Branch Code": "Branch", "Referrer": "Top Referrer"})
+    )
+    branch = branch.merge(top_by_branch, on="Branch", how="left")
+
+    # Channel mix (% Standard)
+    channel_counts = df.groupby("Branch Code")["Referral Type"].value_counts().unstack(fill_value=0)
+    if "Standard" in channel_counts.columns:
+        total_per_branch = channel_counts.sum(axis=1)
+        channel_counts["Standard %"] = channel_counts["Standard"].apply(lambda x: 0.0)
+        for idx in channel_counts.index:
+            channel_counts.loc[idx, "Standard %"] = safe_percentage(
+                channel_counts.loc[idx, "Standard"], total_per_branch[idx]
+            )
+        channel_pct = channel_counts[["Standard %"]].reset_index()
+        channel_pct.rename(columns={"Branch Code": "Branch"}, inplace=True)
+        branch = branch.merge(channel_pct, on="Branch", how="left")
+
+    branch = branch.sort_values("Avg Influence Score", ascending=False).reset_index(drop=True)
+
+    return AnalysisResult(name=name, title=name, df=branch, sheet_name="R06_Branch")

--- a/ics_toolkit/referral/analyses/code_health.py
+++ b/ics_toolkit/referral/analyses/code_health.py
@@ -1,0 +1,52 @@
+"""R07: Referral Code Health Report."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from ics_toolkit.analysis.analyses.base import AnalysisResult, safe_percentage
+from ics_toolkit.referral.analyses.base import ReferralContext
+
+
+def analyze_code_health(ctx: ReferralContext) -> AnalysisResult:
+    """Produce referral code distribution by channel, type, and reliability."""
+    name = "Code Health Report"
+    df = ctx.df.copy()
+
+    if df.empty:
+        empty = pd.DataFrame()
+        return AnalysisResult(
+            name=name,
+            title=name,
+            df=empty,
+            sheet_name="R07_Code_Health",
+        )
+
+    summary = (
+        df.groupby(["Referral Channel", "Referral Type", "Referral Reliability"])
+        .agg(
+            Count=("MRDB Account Hash", "count"),
+        )
+        .reset_index()
+    )
+
+    total = summary["Count"].sum()
+    summary["% of Total"] = summary["Count"].apply(lambda x: safe_percentage(x, total))
+
+    # Known code % (reliability != Low)
+    known_total = summary.loc[summary["Referral Reliability"] != "Low", "Count"].sum()
+    summary["Known Code %"] = safe_percentage(known_total, total)
+
+    summary = summary.sort_values("Count", ascending=False).reset_index(drop=True)
+
+    # Rename for output
+    summary.rename(
+        columns={
+            "Referral Channel": "Channel",
+            "Referral Type": "Type",
+            "Referral Reliability": "Reliability",
+        },
+        inplace=True,
+    )
+
+    return AnalysisResult(name=name, title=name, df=summary, sheet_name="R07_Code_Health")

--- a/ics_toolkit/referral/analyses/dormant_referrers.py
+++ b/ics_toolkit/referral/analyses/dormant_referrers.py
@@ -1,0 +1,57 @@
+"""R03: Dormant High-Value Referrers -- previously active, now inactive."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from ics_toolkit.analysis.analyses.base import AnalysisResult
+from ics_toolkit.referral.analyses.base import ReferralContext
+
+
+def analyze_dormant_referrers(ctx: ReferralContext) -> AnalysisResult:
+    """Identify referrers who were historically high-value but are now dormant.
+
+    Dormant = no referral in last dormancy_days.
+    High-value = unique_accounts >= high_value_min_referrals OR
+    Influence Score in top quartile.
+    """
+    name = "Dormant High-Value Referrers"
+    m = ctx.referrer_metrics.copy()
+
+    if m.empty:
+        return AnalysisResult(name=name, title=name, df=m, sheet_name="R03_Dormant")
+
+    max_date = ctx.df["Issue Date"].max()
+    if pd.isna(max_date):
+        return AnalysisResult(name=name, title=name, df=pd.DataFrame(), sheet_name="R03_Dormant")
+
+    dormancy_cutoff = max_date - pd.Timedelta(days=ctx.settings.dormancy_days)
+
+    # Dormant: last referral before cutoff
+    dormant = m[m["last_referral"] < dormancy_cutoff].copy()
+
+    if dormant.empty:
+        return AnalysisResult(name=name, title=name, df=pd.DataFrame(), sheet_name="R03_Dormant")
+
+    # High-value: meets min referrals OR top quartile influence
+    score_q75 = m["Influence Score"].quantile(0.75) if len(m) >= 4 else 0
+    high_value = dormant[
+        (dormant["unique_accounts"] >= ctx.settings.high_value_min_referrals)
+        | (dormant["Influence Score"] >= score_q75)
+    ].copy()
+
+    high_value["Days Dormant"] = (max_date - high_value["last_referral"]).dt.days
+
+    cols = {
+        "Referrer": "Referrer",
+        "Influence Score": "Historical Score",
+        "total_referrals": "Total Referrals",
+        "unique_accounts": "Unique Accounts",
+        "last_referral": "Last Referral",
+        "Days Dormant": "Days Dormant",
+    }
+    available = {k: v for k, v in cols.items() if k in high_value.columns}
+    out = high_value[list(available.keys())].rename(columns=available)
+    out = out.sort_values("Historical Score", ascending=False).reset_index(drop=True)
+
+    return AnalysisResult(name=name, title=name, df=out, sheet_name="R03_Dormant")

--- a/ics_toolkit/referral/analyses/emerging_referrers.py
+++ b/ics_toolkit/referral/analyses/emerging_referrers.py
@@ -1,0 +1,49 @@
+"""R02: Emerging Referrers -- new and accelerating referrers."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from ics_toolkit.analysis.analyses.base import AnalysisResult
+from ics_toolkit.referral.analyses.base import ReferralContext
+
+
+def analyze_emerging_referrers(ctx: ReferralContext) -> AnalysisResult:
+    """Identify referrers who are new AND accelerating.
+
+    Emerging = first appeared within emerging_lookback_days AND
+    burst_count >= emerging_min_burst_count.
+    """
+    name = "Emerging Referrers"
+    m = ctx.referrer_metrics.copy()
+    df = ctx.df
+
+    if m.empty:
+        return AnalysisResult(name=name, title=name, df=m, sheet_name="R02_Emerging")
+
+    max_date = df["Issue Date"].max()
+    if pd.isna(max_date):
+        return AnalysisResult(name=name, title=name, df=pd.DataFrame(), sheet_name="R02_Emerging")
+
+    lookback_cutoff = max_date - pd.Timedelta(days=ctx.settings.emerging_lookback_days)
+
+    # Filter to new referrers (first referral within lookback window)
+    emerging = m[
+        (m["first_referral"] >= lookback_cutoff)
+        & (m["burst_count"] >= ctx.settings.emerging_min_burst_count)
+    ].copy()
+
+    cols = {
+        "Referrer": "Referrer",
+        "Influence Score": "Influence Score",
+        "burst_count": "Burst Count",
+        "active_days": "Days Active",
+        "first_referral": "First Referral",
+        "last_referral": "Last Referral",
+        "total_referrals": "Total Referrals",
+    }
+    available = {k: v for k, v in cols.items() if k in emerging.columns}
+    out = emerging[list(available.keys())].rename(columns=available)
+    out = out.sort_values("Influence Score", ascending=False).reset_index(drop=True)
+
+    return AnalysisResult(name=name, title=name, df=out, sheet_name="R02_Emerging")

--- a/ics_toolkit/referral/analyses/onetime_vs_repeat.py
+++ b/ics_toolkit/referral/analyses/onetime_vs_repeat.py
@@ -1,0 +1,69 @@
+"""R04: One-time vs Repeat Referrers -- comparison table."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from ics_toolkit.analysis.analyses.base import AnalysisResult, safe_percentage
+from ics_toolkit.referral.analyses.base import ReferralContext
+
+
+def analyze_onetime_vs_repeat(ctx: ReferralContext) -> AnalysisResult:
+    """Compare one-time (1 referral) vs repeat (2+) referrers.
+
+    Output: 2-row comparison table with Grand Total.
+    """
+    name = "One-time vs Repeat Referrers"
+    m = ctx.referrer_metrics.copy()
+
+    if m.empty:
+        return AnalysisResult(name=name, title=name, df=pd.DataFrame(), sheet_name="R04_Repeat")
+
+    m["Category"] = m["total_referrals"].apply(lambda x: "Repeat" if x >= 2 else "One-time")
+
+    summary = (
+        m.groupby("Category")
+        .agg(
+            Count=("Referrer", "count"),
+            **{"Avg Unique Accounts": ("unique_accounts", "mean")},
+            **{"Avg Influence Score": ("Influence Score", "mean")},
+            **{"Avg Active Days": ("active_days", "mean")},
+        )
+        .reset_index()
+    )
+
+    total_count = summary["Count"].sum()
+    summary["% of Total"] = summary["Count"].apply(lambda x: safe_percentage(x, total_count))
+
+    # Reorder columns
+    summary = summary[
+        [
+            "Category",
+            "Count",
+            "% of Total",
+            "Avg Unique Accounts",
+            "Avg Influence Score",
+            "Avg Active Days",
+        ]
+    ]
+
+    # Round floats
+    for col in ["Avg Unique Accounts", "Avg Influence Score", "Avg Active Days"]:
+        summary[col] = summary[col].round(1)
+
+    # Grand Total row
+    total_row = pd.DataFrame(
+        [
+            {
+                "Category": "Grand Total",
+                "Count": total_count,
+                "% of Total": 100.0,
+                "Avg Unique Accounts": m["unique_accounts"].mean().round(1),
+                "Avg Influence Score": m["Influence Score"].mean().round(1),
+                "Avg Active Days": m["active_days"].mean().round(1),
+            }
+        ]
+    )
+    summary = pd.concat([summary, total_row], ignore_index=True)
+
+    return AnalysisResult(name=name, title=name, df=summary, sheet_name="R04_Repeat")

--- a/ics_toolkit/referral/analyses/overview.py
+++ b/ics_toolkit/referral/analyses/overview.py
@@ -1,0 +1,82 @@
+"""R08: Overview KPIs -- summary metrics across all layers."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from ics_toolkit.analysis.analyses.base import AnalysisResult, safe_percentage
+from ics_toolkit.referral.analyses.base import ReferralContext
+
+
+def analyze_overview(
+    ctx: ReferralContext,
+    prior_results: list[AnalysisResult] | None = None,
+) -> AnalysisResult:
+    """Produce headline KPIs for the referral program."""
+    name = "Overview KPIs"
+    df = ctx.df
+    m = ctx.referrer_metrics
+    s = ctx.staff_metrics
+
+    kpis: list[tuple[str, object]] = []
+
+    # Volume metrics
+    kpis.append(("Total Referrals", len(df)))
+    kpis.append(("Unique Referrers", m["Referrer"].nunique() if not m.empty else 0))
+    kpis.append(("Unique New Accounts", df["MRDB Account Hash"].nunique()))
+
+    # Referrer behavior
+    if not m.empty:
+        repeat_count = (m["total_referrals"] >= 2).sum()
+        kpis.append(("Repeat Referrer %", safe_percentage(repeat_count, len(m))))
+        kpis.append(("Avg Referrals per Referrer", round(m["total_referrals"].mean(), 1)))
+        kpis.append(("Top Referrer Score", m["Influence Score"].max()))
+        kpis.append(("Median Influence Score", round(m["Influence Score"].median(), 1)))
+    else:
+        kpis.extend(
+            [
+                ("Repeat Referrer %", 0.0),
+                ("Avg Referrals per Referrer", 0.0),
+                ("Top Referrer Score", 0.0),
+                ("Median Influence Score", 0.0),
+            ]
+        )
+
+    # Temporal
+    if "Days Since Last Referral" in df.columns:
+        avg_gap = df["Days Since Last Referral"].mean()
+        gap_val = round(avg_gap, 1) if pd.notna(avg_gap) else "N/A"
+        kpis.append(("Avg Days Between Referrals", gap_val))
+    if "Is Burst" in df.columns:
+        burst_pct = safe_percentage(df["Is Burst"].sum(), len(df))
+        kpis.append(("Burst Referral %", burst_pct))
+
+    # Staff
+    if not s.empty:
+        top_staff = s.loc[s["Multiplier Score"].idxmax(), "Staff"]
+        kpis.append(("Top Staff (Multiplier)", top_staff))
+    else:
+        kpis.append(("Top Staff (Multiplier)", "N/A"))
+
+    # Branch
+    if "Branch Code" in df.columns:
+        top_branch = df["Branch Code"].value_counts().index[0] if len(df) > 0 else "N/A"
+        kpis.append(("Most Active Branch", top_branch))
+
+    # Code health
+    if "Referral Channel" in df.columns:
+        top_channel = df["Referral Channel"].value_counts().index[0] if len(df) > 0 else "N/A"
+        kpis.append(("Dominant Channel", top_channel))
+    if "Referral Type" in df.columns:
+        manual_pct = safe_percentage((df["Referral Type"] == "Manual").sum(), len(df))
+        exception_pct = safe_percentage((df["Referral Type"] == "Exception").sum(), len(df))
+        kpis.append(("Manual Code %", manual_pct))
+        kpis.append(("Exception Code %", exception_pct))
+
+    # Network
+    if "Network Size" in df.columns:
+        avg_net = df.groupby("Referrer")["Network Size"].max().mean()
+        kpis.append(("Avg Network Size", round(avg_net, 1) if pd.notna(avg_net) else "N/A"))
+
+    out = pd.DataFrame(kpis, columns=["Metric", "Value"])
+    return AnalysisResult(name=name, title=name, df=out, sheet_name="R08_Overview")

--- a/ics_toolkit/referral/analyses/staff_multipliers.py
+++ b/ics_toolkit/referral/analyses/staff_multipliers.py
@@ -1,0 +1,30 @@
+"""R05: Staff Multipliers -- processing reach, NOT influence."""
+
+from __future__ import annotations
+
+from ics_toolkit.analysis.analyses.base import AnalysisResult
+from ics_toolkit.referral.analyses.base import ReferralContext
+
+
+def analyze_staff_multipliers(ctx: ReferralContext) -> AnalysisResult:
+    """Produce the staff multiplier ranking table."""
+    name = "Staff Multipliers"
+    s = ctx.staff_metrics.copy()
+
+    if s.empty:
+        return AnalysisResult(name=name, title=name, df=s, sheet_name="R05_Staff")
+
+    cols = {
+        "Staff": "Staff",
+        "Multiplier Score": "Multiplier Score",
+        "referrals_processed": "Referrals Processed",
+        "unique_referrers": "Unique Referrers",
+        "avg_referrer_score": "Avg Referrer Score",
+        "unique_branches": "Unique Branches",
+    }
+    available = {k: v for k, v in cols.items() if k in s.columns}
+    out = s[list(available.keys())].rename(columns=available)
+    out["Avg Referrer Score"] = out["Avg Referrer Score"].round(1)
+    out = out.sort_values("Multiplier Score", ascending=False).reset_index(drop=True)
+
+    return AnalysisResult(name=name, title=name, df=out, sheet_name="R05_Staff")

--- a/ics_toolkit/referral/analyses/top_referrers.py
+++ b/ics_toolkit/referral/analyses/top_referrers.py
@@ -1,0 +1,40 @@
+"""R01: Top Referrers -- influence-ranked referrer table."""
+
+from __future__ import annotations
+
+from ics_toolkit.analysis.analyses.base import AnalysisResult
+from ics_toolkit.referral.analyses.base import ReferralContext
+
+
+def analyze_top_referrers(ctx: ReferralContext) -> AnalysisResult:
+    """Produce the top N referrers ranked by influence score.
+
+    Excludes single-referral referrers (total_referrals <= 1).
+    """
+    name = "Top Referrers"
+    m = ctx.referrer_metrics.copy()
+
+    if m.empty:
+        return AnalysisResult(name=name, title=name, df=m, sheet_name="R01_Top_Referrers")
+
+    # Exclude single-referral referrers
+    m = m[m["total_referrals"] > 1].copy()
+
+    # Select and rename columns for output
+    cols = {
+        "Referrer": "Referrer",
+        "Influence Score": "Influence Score",
+        "unique_accounts": "Unique Accounts",
+        "total_referrals": "Total Referrals",
+        "burst_count": "Burst Count",
+        "channels_used": "Channels Used",
+        "branches_used": "Branches Used",
+        "max_network_size": "Network Size",
+        "active_days": "Active Days",
+    }
+    available = {k: v for k, v in cols.items() if k in m.columns}
+    out = m[list(available.keys())].rename(columns=available)
+    out = out.sort_values("Influence Score", ascending=False).head(ctx.settings.top_n_referrers)
+    out = out.reset_index(drop=True)
+
+    return AnalysisResult(name=name, title=name, df=out, sheet_name="R01_Top_Referrers")

--- a/ics_toolkit/referral/charts/__init__.py
+++ b/ics_toolkit/referral/charts/__init__.py
@@ -1,0 +1,51 @@
+"""Referral chart registry and dispatcher."""
+
+import logging
+from typing import Callable
+
+import plotly.graph_objects as go
+
+from ics_toolkit.analysis.analyses.base import AnalysisResult
+from ics_toolkit.referral.charts.branch_density import chart_branch_density
+from ics_toolkit.referral.charts.code_health import chart_code_health
+from ics_toolkit.referral.charts.emerging_referrers import chart_emerging_referrers
+from ics_toolkit.referral.charts.staff_multipliers import chart_staff_multipliers
+from ics_toolkit.referral.charts.top_referrers import chart_top_referrers
+from ics_toolkit.settings import ChartConfig
+
+logger = logging.getLogger(__name__)
+
+REFERRAL_CHART_REGISTRY: dict[str, Callable] = {
+    "Top Referrers": chart_top_referrers,
+    "Emerging Referrers": chart_emerging_referrers,
+    "Staff Multipliers": chart_staff_multipliers,
+    "Branch Influence Density": chart_branch_density,
+    "Code Health Report": chart_code_health,
+}
+
+
+def create_referral_charts(
+    analyses: list[AnalysisResult],
+    config: ChartConfig,
+) -> dict[str, go.Figure]:
+    """Build Plotly figures for referral analyses that have chart builders."""
+    charts: dict[str, go.Figure] = {}
+
+    for analysis in analyses:
+        if analysis.error is not None or analysis.df.empty:
+            continue
+
+        builder = REFERRAL_CHART_REGISTRY.get(analysis.name)
+        if builder is None:
+            continue
+
+        try:
+            fig = builder(analysis.df, config)
+            fig.update_layout(title_text=analysis.title)
+            if len(fig.data) == 1 and not isinstance(fig.data[0], go.Pie):
+                fig.update_layout(showlegend=False)
+            charts[analysis.name] = fig
+        except Exception as e:
+            logger.warning("Chart for '%s' failed: %s", analysis.name, e)
+
+    return charts

--- a/ics_toolkit/referral/charts/branch_density.py
+++ b/ics_toolkit/referral/charts/branch_density.py
@@ -1,0 +1,33 @@
+"""Chart for R06: Branch Influence Density -- vertical bar."""
+
+import plotly.graph_objects as go
+
+from ics_toolkit.settings import ChartConfig
+
+LAYOUT_DEFAULTS = dict(
+    legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
+    margin=dict(t=60, b=40),
+)
+
+
+def chart_branch_density(df, config: ChartConfig) -> go.Figure:
+    """Vertical bar of avg influence score per branch, sorted descending."""
+    data = df.sort_values("Avg Influence Score", ascending=False).copy()
+
+    fig = go.Figure(
+        go.Bar(
+            x=data["Branch"],
+            y=data["Avg Influence Score"],
+            marker_color=config.colors[0],
+            text=data["Avg Influence Score"],
+            textposition="outside",
+        )
+    )
+
+    fig.update_layout(
+        template=config.theme,
+        xaxis_title="Branch",
+        yaxis_title="Avg Influence Score",
+        **LAYOUT_DEFAULTS,
+    )
+    return fig

--- a/ics_toolkit/referral/charts/code_health.py
+++ b/ics_toolkit/referral/charts/code_health.py
@@ -1,0 +1,41 @@
+"""Chart for R07: Code Health -- stacked bar by reliability tier."""
+
+import plotly.graph_objects as go
+
+from ics_toolkit.settings import ChartConfig
+
+LAYOUT_DEFAULTS = dict(
+    legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
+    margin=dict(t=60, b=40),
+)
+
+
+def chart_code_health(df, config: ChartConfig) -> go.Figure:
+    """Stacked bar chart: code category distribution by Reliability tier."""
+    data = df.copy()
+    colors = config.colors
+
+    # Group by Channel+Type, split by Reliability
+    reliabilities = data["Reliability"].unique()
+    data["Label"] = data["Channel"] + " / " + data["Type"]
+
+    fig = go.Figure()
+    for i, rel in enumerate(reliabilities):
+        subset = data[data["Reliability"] == rel]
+        fig.add_trace(
+            go.Bar(
+                x=subset["Label"],
+                y=subset["Count"],
+                name=rel,
+                marker_color=colors[i % len(colors)],
+            )
+        )
+
+    fig.update_layout(
+        template=config.theme,
+        barmode="stack",
+        xaxis_title="Channel / Type",
+        yaxis_title="Count",
+        **LAYOUT_DEFAULTS,
+    )
+    return fig

--- a/ics_toolkit/referral/charts/emerging_referrers.py
+++ b/ics_toolkit/referral/charts/emerging_referrers.py
@@ -1,0 +1,44 @@
+"""Chart for R02: Emerging Referrers -- scatter timeline."""
+
+import plotly.graph_objects as go
+
+from ics_toolkit.settings import ChartConfig
+
+LAYOUT_DEFAULTS = dict(
+    legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
+    margin=dict(t=60, b=40),
+)
+
+
+def chart_emerging_referrers(df, config: ChartConfig) -> go.Figure:
+    """Scatter plot: Referrer (y) x First Referral date (x), size = Burst Count."""
+    data = df.copy()
+    marker_size = data["Burst Count"].clip(lower=1) * 8
+
+    fig = go.Figure(
+        go.Scatter(
+            x=data["First Referral"],
+            y=data["Referrer"],
+            mode="markers",
+            marker=dict(
+                size=marker_size,
+                color=data["Influence Score"],
+                colorscale="Blues",
+                showscale=True,
+                colorbar=dict(title="Score"),
+            ),
+            text=data.apply(
+                lambda r: f"Score: {r['Influence Score']}<br>Bursts: {r['Burst Count']}",
+                axis=1,
+            ),
+            hoverinfo="text+y",
+        )
+    )
+
+    fig.update_layout(
+        template=config.theme,
+        xaxis_title="First Referral Date",
+        yaxis_title="Referrer",
+        **LAYOUT_DEFAULTS,
+    )
+    return fig

--- a/ics_toolkit/referral/charts/staff_multipliers.py
+++ b/ics_toolkit/referral/charts/staff_multipliers.py
@@ -1,0 +1,49 @@
+"""Chart for R05: Staff Multipliers -- grouped bar."""
+
+import plotly.graph_objects as go
+
+from ics_toolkit.settings import ChartConfig
+
+LAYOUT_DEFAULTS = dict(
+    legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
+    margin=dict(t=60, b=40),
+)
+
+
+def chart_staff_multipliers(df, config: ChartConfig) -> go.Figure:
+    """Grouped bar: multiplier score (primary) and referrals processed (secondary)."""
+    data = df.sort_values("Multiplier Score", ascending=False).copy()
+    colors = config.colors
+
+    fig = go.Figure()
+
+    fig.add_trace(
+        go.Bar(
+            x=data["Staff"],
+            y=data["Multiplier Score"],
+            name="Multiplier Score",
+            marker_color=colors[0],
+            yaxis="y",
+        )
+    )
+
+    if "Referrals Processed" in data.columns:
+        fig.add_trace(
+            go.Bar(
+                x=data["Staff"],
+                y=data["Referrals Processed"],
+                name="Referrals Processed",
+                marker_color=colors[1],
+                yaxis="y2",
+            )
+        )
+
+    fig.update_layout(
+        template=config.theme,
+        barmode="group",
+        xaxis_title="Staff",
+        yaxis=dict(title="Multiplier Score"),
+        yaxis2=dict(title="Referrals Processed", overlaying="y", side="right"),
+        **LAYOUT_DEFAULTS,
+    )
+    return fig

--- a/ics_toolkit/referral/charts/top_referrers.py
+++ b/ics_toolkit/referral/charts/top_referrers.py
@@ -1,0 +1,34 @@
+"""Chart for R01: Top Referrers -- horizontal bar by influence score."""
+
+import plotly.graph_objects as go
+
+from ics_toolkit.settings import ChartConfig
+
+LAYOUT_DEFAULTS = dict(
+    legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
+    margin=dict(t=60, b=40),
+)
+
+
+def chart_top_referrers(df, config: ChartConfig) -> go.Figure:
+    """Horizontal bar chart of top referrers ranked by influence score."""
+    data = df.sort_values("Influence Score", ascending=True).copy()
+
+    fig = go.Figure(
+        go.Bar(
+            x=data["Influence Score"],
+            y=data["Referrer"],
+            orientation="h",
+            marker_color=config.colors[0],
+            text=data["Influence Score"],
+            textposition="outside",
+        )
+    )
+
+    fig.update_layout(
+        template=config.theme,
+        xaxis_title="Influence Score",
+        yaxis_title="Referrer",
+        **LAYOUT_DEFAULTS,
+    )
+    return fig

--- a/ics_toolkit/referral/code_decoder.py
+++ b/ics_toolkit/referral/code_decoder.py
@@ -1,0 +1,59 @@
+"""Layer 2: Referral code decoding and classification."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+if TYPE_CHECKING:
+    from ics_toolkit.settings import ReferralSettings
+
+# Channel -> Type mapping
+_CHANNEL_TYPE_MAP = {
+    "BRANCH_STANDARD": "Standard",
+    "DIGITAL_PROCESS": "Standard",
+    "EMAIL": "Standard",
+    "MANUAL": "Manual",
+    "OTHER": "Exception",
+}
+
+# Type -> Reliability mapping
+_TYPE_RELIABILITY_MAP = {
+    "Standard": "High",
+    "Manual": "Medium",
+    "Exception": "Low",
+}
+
+
+def decode_referral_codes(df: pd.DataFrame, settings: "ReferralSettings") -> pd.DataFrame:
+    """Decode referral codes into channel, type, and reliability tags.
+
+    Added columns: Referral Channel, Referral Type, Referral Reliability
+    """
+    df = df.copy()
+    sorted_prefixes = sorted(settings.code_prefix_map.keys(), key=len, reverse=True)
+
+    df["Referral Channel"] = df["Referral Code"].apply(
+        lambda c: _classify_channel(c, sorted_prefixes, settings.code_prefix_map)
+    )
+    df["Referral Type"] = df["Referral Channel"].map(_CHANNEL_TYPE_MAP).fillna("Exception")
+    df["Referral Reliability"] = df["Referral Type"].map(_TYPE_RELIABILITY_MAP)
+    return df
+
+
+def _classify_channel(
+    code: object,
+    sorted_prefixes: list[str],
+    prefix_map: dict[str, str],
+) -> str:
+    """Classify a single referral code into a channel."""
+    if pd.isna(code) or str(code).strip() in ("", "None", "none", "NONE"):
+        return "MANUAL"
+    code_str = str(code).strip().upper()
+    for prefix in sorted_prefixes:
+        if code_str.startswith(prefix.upper()):
+            return prefix_map[prefix]
+    if "EMAIL" in code_str:
+        return "EMAIL"
+    return "OTHER"

--- a/ics_toolkit/referral/column_map.py
+++ b/ics_toolkit/referral/column_map.py
@@ -1,0 +1,40 @@
+"""Required columns and aliases for referral data files."""
+
+REQUIRED_COLUMNS = [
+    "Referrer Name",
+    "Issue Date",
+    "Referral Code",
+    "Purchase Manager",
+    "Branch",
+    "Account Holder",
+    "MRDB Account Hash",
+    "Cert ID",
+]
+
+# Maps common alternative names (lowercase) -> canonical column name.
+COLUMN_ALIASES: dict[str, str] = {
+    "referrer": "Referrer Name",
+    "referrer_name": "Referrer Name",
+    "referrer name": "Referrer Name",
+    "issue_date": "Issue Date",
+    "issue date": "Issue Date",
+    "date": "Issue Date",
+    "referral_code": "Referral Code",
+    "referral code": "Referral Code",
+    "code": "Referral Code",
+    "purchase_manager": "Purchase Manager",
+    "purchase manager": "Purchase Manager",
+    "staff": "Purchase Manager",
+    "branch": "Branch",
+    "branch_id": "Branch",
+    "account_holder": "Account Holder",
+    "account holder": "Account Holder",
+    "new_account": "Account Holder",
+    "mrdb_account_hash": "MRDB Account Hash",
+    "mrdb account hash": "MRDB Account Hash",
+    "mrdb": "MRDB Account Hash",
+    "account_hash": "MRDB Account Hash",
+    "cert_id": "Cert ID",
+    "cert id": "Cert ID",
+    "certificate_id": "Cert ID",
+}

--- a/ics_toolkit/referral/data_loader.py
+++ b/ics_toolkit/referral/data_loader.py
@@ -1,0 +1,136 @@
+"""Load and validate referral data files."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+from ics_toolkit.exceptions import DataError
+from ics_toolkit.referral.column_map import COLUMN_ALIASES, REQUIRED_COLUMNS
+
+if TYPE_CHECKING:
+    from ics_toolkit.settings import ReferralSettings
+
+logger = logging.getLogger(__name__)
+
+
+def load_referral_data(settings: "ReferralSettings") -> pd.DataFrame:
+    """Load and validate a referral data file.
+
+    Steps:
+    1. Read file (detect format by suffix)
+    2. Resolve column aliases
+    3. Validate required columns
+    4. Drop rows where MRDB Account Hash is null
+    5. Parse Issue Date as datetime
+    6. Log warnings for data quality issues
+    """
+    if settings.data_file is None:
+        raise DataError("No referral data file specified.")
+
+    df = _read_file(settings.data_file, settings.header_row)
+    df = _resolve_aliases(df)
+    _validate_columns(df, settings.data_file)
+    df = _validate_primary_key(df)
+    df = _parse_dates(df)
+    _warn_data_quality(df)
+    logger.info("Loaded %d referral records from %s", len(df), settings.data_file.name)
+    return df
+
+
+def _read_file(path: Path, header_row: int = 0) -> pd.DataFrame:
+    """Read file, choosing engine by suffix."""
+    suffix = path.suffix.lower()
+    try:
+        if suffix == ".csv":
+            return pd.read_csv(path, header=header_row)
+        elif suffix == ".xls":
+            return pd.read_excel(path, header=header_row, engine="xlrd")
+        elif suffix == ".xlsx":
+            return pd.read_excel(path, header=header_row, engine="openpyxl")
+        else:
+            raise DataError(f"Unsupported file type: {suffix}")
+    except ImportError as e:
+        if "xlrd" in str(e):
+            raise DataError(
+                "The 'xlrd' package is required to read .xls files. "
+                "Install it with: pip install xlrd"
+            ) from e
+        raise
+    except Exception as e:
+        raise DataError(f"Failed to read {path.name}: {e}") from e
+
+
+def _resolve_aliases(df: pd.DataFrame) -> pd.DataFrame:
+    """Map alternative column names to canonical names."""
+    rename_map: dict[str, str] = {}
+    for col in df.columns:
+        lower = col.strip().lower().replace("-", "_")
+        if col not in REQUIRED_COLUMNS and lower in COLUMN_ALIASES:
+            canonical = COLUMN_ALIASES[lower]
+            if canonical not in df.columns:
+                rename_map[col] = canonical
+    if rename_map:
+        logger.debug("Column aliases resolved: %s", rename_map)
+        df = df.rename(columns=rename_map)
+    return df
+
+
+def _validate_columns(df: pd.DataFrame, path: Path) -> None:
+    """Ensure all required columns are present."""
+    missing = [c for c in REQUIRED_COLUMNS if c not in df.columns]
+    if missing:
+        available = ", ".join(sorted(df.columns))
+        raise DataError(
+            f"Missing required columns in {path.name}: {missing}\nAvailable columns: {available}"
+        )
+
+
+def _validate_primary_key(df: pd.DataFrame) -> pd.DataFrame:
+    """Drop rows where MRDB Account Hash is null."""
+    null_pk = df["MRDB Account Hash"].isna()
+    if null_pk.all():
+        raise DataError("All rows have null MRDB Account Hash -- file has no usable data.")
+    if null_pk.any():
+        count = null_pk.sum()
+        logger.warning("Dropped %d rows with null MRDB Account Hash", count)
+        df = df[~null_pk].copy()
+    return df
+
+
+def _parse_dates(df: pd.DataFrame) -> pd.DataFrame:
+    """Parse Issue Date as datetime."""
+    df = df.copy()
+    df["Issue Date"] = pd.to_datetime(df["Issue Date"], errors="coerce")
+    nat_count = df["Issue Date"].isna().sum()
+    if nat_count > 0:
+        logger.warning(
+            "%d rows have unparseable Issue Date (will be excluded from temporal analysis)",
+            nat_count,
+        )
+    return df
+
+
+def _warn_data_quality(df: pd.DataFrame) -> None:
+    """Log warnings for common data quality issues."""
+    # Null Cert ID
+    null_cert = df["Cert ID"].isna().sum()
+    if null_cert > 0:
+        logger.warning("%d rows have null Cert ID", null_cert)
+
+    # Future dates
+    now = pd.Timestamp.now()
+    future = df["Issue Date"].dropna() > now
+    if future.any():
+        logger.warning("%d rows have future Issue Date", future.sum())
+
+    # Duplicate MRDB + Cert ID pairs
+    dups = df.duplicated(subset=["MRDB Account Hash", "Cert ID"], keep=False)
+    if dups.any():
+        logger.warning(
+            "%d rows have duplicate MRDB Account Hash + Cert ID pairs",
+            dups.sum(),
+        )

--- a/ics_toolkit/referral/exports/__init__.py
+++ b/ics_toolkit/referral/exports/__init__.py
@@ -1,0 +1,1 @@
+"""Referral export modules."""

--- a/ics_toolkit/referral/exports/excel.py
+++ b/ics_toolkit/referral/exports/excel.py
@@ -1,0 +1,103 @@
+"""Referral intelligence Excel report -- reuses analysis export styles."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+
+from ics_toolkit.analysis.analyses.base import AnalysisResult
+from ics_toolkit.analysis.exports.excel import (
+    _register_styles,
+    _write_analysis_sheet,
+    _write_toc_sheet,
+)
+from ics_toolkit.settings import ReferralSettings
+
+try:
+    from openpyxl import Workbook
+    from openpyxl.styles import Font
+except ImportError:
+    Workbook = None  # type: ignore[assignment,misc]
+
+logger = logging.getLogger(__name__)
+
+NAVY = "1B365D"
+
+
+def _write_referral_cover(
+    wb: "Workbook",
+    settings: ReferralSettings,
+    df: pd.DataFrame,
+    analyses: list[AnalysisResult],
+) -> None:
+    """Write cover sheet for the referral report."""
+    ws = wb.active
+    ws.title = "Report Info"
+    ws.sheet_properties.showGridLines = False
+
+    ws.merge_cells("A1:D1")
+    cell = ws["A1"]
+    cell.value = "Referral Intelligence Report"
+    cell.font = Font(name="Calibri", size=24, bold=True, color=NAVY)
+
+    ws.merge_cells("A2:D2")
+    ws["A2"].value = settings.client_name or f"Client {settings.client_id or 'unknown'}"
+    ws["A2"].font = Font(name="Calibri", size=16, color="666666")
+
+    now = datetime.now()
+    details = [
+        ("Client ID:", settings.client_id or "unknown"),
+        ("Report Date:", now.strftime("%B %d, %Y")),
+        ("Source File:", settings.data_file.name if settings.data_file else "N/A"),
+        ("Total Referral Records:", f"{len(df):,}"),
+        (
+            "Unique Referrers:",
+            (f"{df['Referrer'].nunique():,}" if "Referrer" in df.columns else "N/A"),
+        ),
+        ("Analyses Run:", str(sum(1 for a in analyses if a.error is None))),
+    ]
+
+    for i, (label, value) in enumerate(details, start=4):
+        ws[f"A{i}"].value = label
+        ws[f"A{i}"].font = Font(name="Calibri", bold=True, size=11)
+        ws[f"B{i}"].value = value
+        ws[f"B{i}"].font = Font(name="Calibri", size=11)
+
+    ws.column_dimensions["A"].width = 25
+    ws.column_dimensions["B"].width = 50
+
+
+def write_referral_excel(
+    settings: ReferralSettings,
+    df: pd.DataFrame,
+    analyses: list[AnalysisResult],
+    output_path: Path | None = None,
+    chart_pngs: dict[str, bytes] | None = None,
+) -> Path:
+    """Write the referral intelligence Excel report.
+
+    Reuses NamedStyles and sheet writers from the analysis export module.
+    """
+    if output_path is None:
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        output_path = settings.output_dir / f"Referral_Intelligence_{timestamp}.xlsx"
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    wb = Workbook()
+    _register_styles(wb)
+    _write_referral_cover(wb, settings, df, analyses)
+    _write_toc_sheet(wb, analyses)
+
+    pngs = chart_pngs or {}
+    for analysis in analyses:
+        if analysis.error is not None:
+            continue
+        _write_analysis_sheet(wb, analysis, chart_png=pngs.get(analysis.name))
+
+    wb.save(output_path)
+    logger.info("Referral Excel report saved: %s", output_path)
+    return output_path

--- a/ics_toolkit/referral/exports/pptx.py
+++ b/ics_toolkit/referral/exports/pptx.py
@@ -1,0 +1,118 @@
+"""Referral intelligence PPTX report -- reuses analysis PPTX infrastructure."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from ics_toolkit.analysis.analyses.base import AnalysisResult
+from ics_toolkit.analysis.exports.pptx import (
+    SLIDE_HEIGHT,
+    SLIDE_WIDTH,
+    _add_chart_slide,
+    _add_section_divider,
+    _add_table_slide,
+    _build_analysis_lookup,
+    _get_layout,
+)
+from ics_toolkit.settings import ReferralSettings
+
+try:
+    from pptx import Presentation
+except ImportError:
+    Presentation = None  # type: ignore[assignment,misc]
+
+logger = logging.getLogger(__name__)
+
+REFERRAL_SECTION_MAP = {
+    "Referral Intelligence Overview": ["Overview KPIs"],
+    "Referrer Influence": [
+        "Top Referrers",
+        "Emerging Referrers",
+        "Dormant High-Value Referrers",
+        "One-time vs Repeat Referrers",
+    ],
+    "Staff & Branch": [
+        "Staff Multipliers",
+        "Branch Influence Density",
+    ],
+    "Code Health": ["Code Health Report"],
+}
+
+_MAPPED_NAMES: set[str] = set()
+for _names in REFERRAL_SECTION_MAP.values():
+    _MAPPED_NAMES.update(_names)
+
+
+def write_referral_pptx(
+    settings: ReferralSettings,
+    analyses: list[AnalysisResult],
+    output_path: Path | None = None,
+    chart_pngs: dict[str, bytes] | None = None,
+) -> Path:
+    """Build and save a PPTX presentation for referral intelligence.
+
+    Reuses slide builders from the analysis export module.
+    """
+    if output_path is None:
+        output_path = settings.output_dir / "Referral_Intelligence.pptx"
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    lookup = _build_analysis_lookup(analyses)
+    pngs = chart_pngs or {}
+
+    # Create presentation
+    template = settings.pptx_template
+    if template and Path(template).exists():
+        prs = Presentation(str(template))
+        logger.info("Loaded template: %s", template)
+    else:
+        prs = Presentation()
+        prs.slide_width = SLIDE_WIDTH
+        prs.slide_height = SLIDE_HEIGHT
+        if template:
+            logger.warning("Template not found: %s (using blank)", template)
+
+    # Title slide
+    layout = _get_layout(prs, preferred=1, fallback=0)
+    slide = prs.slides.add_slide(layout)
+    if slide.shapes.title:
+        slide.shapes.title.text = "Referral Intelligence Report"
+    subtitle = settings.client_name or (f"Client {settings.client_id or 'unknown'}")
+    for ph_idx in [1, 13, 14]:
+        try:
+            slide.placeholders[ph_idx].text = subtitle
+            break
+        except (KeyError, IndexError):
+            continue
+
+    # Walk section map
+    for section_name, analysis_names in REFERRAL_SECTION_MAP.items():
+        section_analyses = [(name, lookup[name]) for name in analysis_names if name in lookup]
+        if not section_analyses:
+            continue
+
+        _add_section_divider(prs, section_name)
+
+        for name, analysis in section_analyses:
+            _add_table_slide(prs, analysis)
+            if name in pngs:
+                _add_chart_slide(prs, analysis.title, pngs[name])
+
+    # Catch unmapped analyses
+    unmapped = [(a.name, a) for a in analyses if a.error is None and a.name not in _MAPPED_NAMES]
+    if unmapped:
+        _add_section_divider(prs, "Additional Analyses")
+        for name, analysis in unmapped:
+            _add_table_slide(prs, analysis)
+            if name in pngs:
+                _add_chart_slide(prs, analysis.title, pngs[name])
+
+    prs.save(str(output_path))
+    logger.info(
+        "Referral PPTX report saved: %s (%d slides)",
+        output_path,
+        len(prs.slides),
+    )
+    return output_path

--- a/ics_toolkit/referral/network.py
+++ b/ics_toolkit/referral/network.py
@@ -1,0 +1,27 @@
+"""Layer 4: Household/network inference via soft signals."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def infer_networks(df: pd.DataFrame) -> pd.DataFrame:
+    """Infer household/network relationships via shared referrer + account surname.
+
+    Added columns: Network ID, Network Size
+    """
+    df = df.copy()
+    network_map = (
+        df.groupby(["Referrer", "Account Surname"])
+        .agg(network_size=("MRDB Account Hash", "nunique"))
+        .reset_index()
+    )
+    network_map["Network ID"] = network_map["Referrer"] + ":" + network_map["Account Surname"]
+
+    df = df.merge(
+        network_map[["Referrer", "Account Surname", "Network ID", "network_size"]],
+        on=["Referrer", "Account Surname"],
+        how="left",
+    )
+    df.rename(columns={"network_size": "Network Size"}, inplace=True)
+    return df

--- a/ics_toolkit/referral/normalizer.py
+++ b/ics_toolkit/referral/normalizer.py
@@ -1,0 +1,65 @@
+"""Layer 1: Entity normalization for referral data."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+if TYPE_CHECKING:
+    from ics_toolkit.settings import ReferralSettings
+
+SUFFIXES = frozenset({"JR", "SR", "II", "III", "IV", "V"})
+
+
+def normalize_entities(df: pd.DataFrame, settings: "ReferralSettings") -> pd.DataFrame:
+    """Standardize entity names. Adds canonical columns without overwriting originals.
+
+    Added columns: Referrer, New Account, Staff, Branch Code, Branch Label,
+    Referrer Surname, Account Surname
+    """
+    df = df.copy()
+    df["Referrer"] = _normalize_name(df["Referrer Name"], settings.name_aliases, "UNKNOWN")
+    df["New Account"] = _normalize_name(df["Account Holder"], settings.name_aliases, "UNKNOWN")
+    df["Staff"] = _normalize_name(df["Purchase Manager"], settings.name_aliases, "UNASSIGNED")
+    df["Branch Code"] = df["Branch"].fillna("UNKNOWN").astype(str).str.strip()
+
+    if settings.branch_mapping:
+        mapped = df["Branch Code"].map(settings.branch_mapping)
+        df["Branch Label"] = mapped.fillna(df["Branch Code"])
+    else:
+        df["Branch Label"] = df["Branch Code"]
+
+    df["Referrer Surname"] = _extract_surname(df["Referrer"])
+    df["Account Surname"] = _extract_surname(df["New Account"])
+    return df
+
+
+def _normalize_name(
+    series: pd.Series,
+    aliases: dict[str, str],
+    null_sentinel: str,
+) -> pd.Series:
+    """Strip, uppercase, collapse whitespace, apply alias table."""
+    normalized = series.fillna(null_sentinel).astype(str).str.strip().str.upper()
+    normalized = normalized.apply(lambda n: re.sub(r"\s+", " ", n))
+    normalized = normalized.replace("", null_sentinel)
+    if aliases:
+        upper_aliases = {k.upper(): v.upper() for k, v in aliases.items()}
+        normalized = normalized.map(lambda n: upper_aliases.get(n, n))
+    return normalized
+
+
+def _extract_surname(series: pd.Series) -> pd.Series:
+    """Extract surname from full name, skipping common suffixes."""
+
+    def _surname(name: str) -> str:
+        parts = name.split()
+        if len(parts) <= 1:
+            return name
+        if parts[-1] in SUFFIXES and len(parts) > 2:
+            return parts[-2]
+        return parts[-1]
+
+    return series.apply(_surname)

--- a/ics_toolkit/referral/pipeline.py
+++ b/ics_toolkit/referral/pipeline.py
@@ -1,0 +1,210 @@
+"""Referral intelligence pipeline orchestrator."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Callable
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from ics_toolkit.analysis.analyses.base import AnalysisResult
+from ics_toolkit.referral.analyses import run_all_referral_analyses
+from ics_toolkit.referral.analyses.base import ReferralContext
+from ics_toolkit.referral.charts import create_referral_charts
+from ics_toolkit.referral.code_decoder import decode_referral_codes
+from ics_toolkit.referral.data_loader import load_referral_data
+from ics_toolkit.referral.network import infer_networks
+from ics_toolkit.referral.normalizer import normalize_entities
+from ics_toolkit.referral.scoring import (
+    compute_influence_scores,
+    compute_referrer_metrics,
+    compute_staff_multipliers,
+)
+from ics_toolkit.referral.temporal import add_temporal_signals
+from ics_toolkit.settings import ReferralSettings
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ReferralPipelineResult:
+    """Result of the referral intelligence pipeline."""
+
+    settings: ReferralSettings
+    df: pd.DataFrame
+    referrer_metrics: pd.DataFrame
+    staff_metrics: pd.DataFrame
+    analyses: list[AnalysisResult] = field(default_factory=list)
+    charts: dict[str, go.Figure] = field(default_factory=dict)
+    chart_pngs: dict[str, bytes] = field(default_factory=dict)
+
+
+def run_pipeline(
+    settings: ReferralSettings,
+    on_progress: Callable[[int, int, str], None] | None = None,
+    skip_charts: bool = False,
+) -> ReferralPipelineResult:
+    """Execute the referral intelligence pipeline.
+
+    Steps:
+    1. Load + validate data
+    2. Entity normalization
+    3. Code decoding
+    4. Temporal signals
+    5. Network inference
+    6. Influence scoring + staff multipliers
+    7. Run 8 analysis artifacts
+    8. Build charts + render PNGs
+    """
+    total_steps = 7 if skip_charts else 8
+
+    # Step 1: Load data
+    logger.info("[1/%d] Loading referral data...", total_steps)
+    if on_progress:
+        on_progress(0, total_steps, "Loading referral data...")
+    df = load_referral_data(settings)
+    logger.info("Loaded %d referral records", len(df))
+
+    # Step 2: Entity normalization
+    logger.info("[2/%d] Normalizing entities...", total_steps)
+    if on_progress:
+        on_progress(1, total_steps, "Normalizing entities...")
+    df = normalize_entities(df, settings)
+
+    # Step 3: Code decoding
+    logger.info("[3/%d] Decoding referral codes...", total_steps)
+    if on_progress:
+        on_progress(2, total_steps, "Decoding referral codes...")
+    df = decode_referral_codes(df, settings)
+
+    # Step 4: Temporal signals
+    logger.info("[4/%d] Computing temporal signals...", total_steps)
+    if on_progress:
+        on_progress(3, total_steps, "Computing temporal signals...")
+    df = add_temporal_signals(df, settings)
+
+    # Step 5: Network inference
+    logger.info("[5/%d] Inferring referral networks...", total_steps)
+    if on_progress:
+        on_progress(4, total_steps, "Inferring networks...")
+    df = infer_networks(df)
+
+    # Step 6: Scoring
+    logger.info("[6/%d] Computing influence scores...", total_steps)
+    if on_progress:
+        on_progress(5, total_steps, "Computing influence scores...")
+    referrer_metrics = compute_referrer_metrics(df)
+    referrer_metrics = compute_influence_scores(referrer_metrics, settings.scoring_weights)
+    staff_metrics = compute_staff_multipliers(df, referrer_metrics, settings.staff_weights)
+    logger.info(
+        "Scored %d referrers, %d staff members",
+        len(referrer_metrics),
+        len(staff_metrics),
+    )
+
+    # Step 7: Run analyses
+    logger.info("[7/%d] Running 8 referral analyses...", total_steps)
+    if on_progress:
+        on_progress(6, total_steps, "Running analyses...")
+    ctx = ReferralContext(
+        df=df,
+        referrer_metrics=referrer_metrics,
+        staff_metrics=staff_metrics,
+        settings=settings,
+    )
+    analyses = run_all_referral_analyses(ctx)
+    successful = [a for a in analyses if a.error is None]
+    failed = [a for a in analyses if a.error is not None]
+    if failed:
+        for a in failed:
+            logger.warning("Skipped: %s (%s)", a.name, a.error)
+    logger.info("%d/%d analyses completed", len(successful), len(analyses))
+
+    # Step 8: Charts
+    charts: dict[str, go.Figure] = {}
+    chart_pngs: dict[str, bytes] = {}
+    if skip_charts:
+        logger.info("[8/%d] Skipping charts (--no-charts)", total_steps)
+    else:
+        logger.info("[8/%d] Building charts...", total_steps)
+        if on_progress:
+            on_progress(7, total_steps, "Building charts...")
+        try:
+            charts = create_referral_charts(analyses, settings.charts)
+            logger.info("Built %d charts", len(charts))
+        except Exception as e:
+            logger.error("Chart generation failed: %s", e, exc_info=True)
+
+        if charts:
+            from ics_toolkit.analysis.charts.renderer import render_all_chart_pngs
+
+            try:
+                chart_pngs = render_all_chart_pngs(charts)
+                logger.info("Rendered %d chart PNGs", len(chart_pngs))
+            except Exception as e:
+                logger.error("Chart PNG rendering failed: %s", e, exc_info=True)
+
+    return ReferralPipelineResult(
+        settings=settings,
+        df=df,
+        referrer_metrics=referrer_metrics,
+        staff_metrics=staff_metrics,
+        analyses=analyses,
+        charts=charts,
+        chart_pngs=chart_pngs,
+    )
+
+
+def export_outputs(
+    result: ReferralPipelineResult,
+    skip_charts: bool = False,
+) -> list[Path]:
+    """Export pipeline results to configured output formats.
+
+    Returns list of generated file paths.
+    """
+    settings = result.settings
+    settings.output_dir.mkdir(parents=True, exist_ok=True)
+
+    generated: list[Path] = []
+    date_str = datetime.now().strftime("%Y%m%d")
+    client_id = settings.client_id or "unknown"
+
+    if settings.outputs.excel:
+        try:
+            from ics_toolkit.referral.exports.excel import write_referral_excel
+
+            logger.info("Writing referral Excel report...")
+            path = settings.output_dir / f"{client_id}_Referral_Intelligence_{date_str}.xlsx"
+            write_referral_excel(
+                settings,
+                result.df,
+                result.analyses,
+                output_path=path,
+                chart_pngs=result.chart_pngs,
+            )
+            generated.append(path)
+        except Exception as e:
+            logger.error("Excel report failed: %s", e, exc_info=True)
+
+    if settings.outputs.powerpoint:
+        try:
+            from ics_toolkit.referral.exports.pptx import write_referral_pptx
+
+            logger.info("Writing referral PowerPoint report...")
+            path = settings.output_dir / f"{client_id}_Referral_Intelligence_{date_str}.pptx"
+            write_referral_pptx(
+                settings,
+                result.analyses,
+                output_path=path,
+                chart_pngs=result.chart_pngs,
+            )
+            generated.append(path)
+        except Exception as e:
+            logger.error("PowerPoint report failed: %s", e, exc_info=True)
+
+    return generated

--- a/ics_toolkit/referral/scoring.py
+++ b/ics_toolkit/referral/scoring.py
@@ -1,0 +1,144 @@
+"""Layer 5: Influence scoring and staff multiplier computation."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+if TYPE_CHECKING:
+    from ics_toolkit.settings import ReferralScoringWeights, ReferralStaffWeights
+
+logger = logging.getLogger(__name__)
+
+
+def compute_referrer_metrics(df: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate per-referrer metrics for influence scoring.
+
+    Excludes referrers where Referrer == 'UNKNOWN'.
+    """
+    scored_df = df[df["Referrer"] != "UNKNOWN"].copy()
+    if scored_df.empty:
+        return pd.DataFrame(
+            columns=[
+                "Referrer",
+                "total_referrals",
+                "unique_accounts",
+                "active_days",
+                "burst_count",
+                "avg_days_between",
+                "channels_used",
+                "branches_used",
+                "first_referral",
+                "last_referral",
+                "network_count",
+                "max_network_size",
+            ]
+        )
+
+    metrics = (
+        scored_df.groupby("Referrer")
+        .agg(
+            total_referrals=("New Account", "count"),
+            unique_accounts=("MRDB Account Hash", "nunique"),
+            active_days=(
+                "Issue Date",
+                lambda x: (x.max() - x.min()).days + 1 if x.notna().any() else 0,
+            ),
+            burst_count=("Is Burst", "sum"),
+            avg_days_between=("Days Since Last Referral", "mean"),
+            channels_used=("Referral Channel", "nunique"),
+            branches_used=("Branch Code", "nunique"),
+            first_referral=("Issue Date", "min"),
+            last_referral=("Issue Date", "max"),
+            network_count=("Network ID", "nunique"),
+            max_network_size=("Network Size", "max"),
+        )
+        .reset_index()
+    )
+    return metrics
+
+
+def compute_influence_scores(
+    metrics: pd.DataFrame,
+    weights: "ReferralScoringWeights",
+) -> pd.DataFrame:
+    """Compute weighted composite influence score (0-100)."""
+    if metrics.empty:
+        metrics["Influence Score"] = pd.Series(dtype=float)
+        return metrics
+
+    m = metrics.copy()
+    m["avg_days_between"] = m["avg_days_between"].fillna(0)
+
+    logger.info(
+        "Scoring weights: accounts=%.2f burst=%.2f channels=%.2f velocity=%.2f longevity=%.2f",
+        weights.unique_accounts,
+        weights.burst_count,
+        weights.channels_used,
+        weights.velocity,
+        weights.longevity,
+    )
+
+    m["score"] = (
+        weights.unique_accounts * _safe_minmax(m["unique_accounts"])
+        + weights.burst_count * _safe_minmax(m["burst_count"])
+        + weights.channels_used * _safe_minmax(m["channels_used"])
+        + weights.velocity * _safe_minmax(1 / (m["avg_days_between"] + 1))
+        + weights.longevity * _safe_minmax(m["active_days"])
+    )
+    m["Influence Score"] = (_safe_minmax(m["score"]) * 100).round(1)
+    return m
+
+
+def compute_staff_multipliers(
+    df: pd.DataFrame,
+    referrer_metrics: pd.DataFrame,
+    weights: "ReferralStaffWeights",
+) -> pd.DataFrame:
+    """Compute staff multiplier scores (processing reach, NOT influence)."""
+    scored_df = df[df["Staff"] != "UNASSIGNED"].copy()
+    if scored_df.empty or referrer_metrics.empty:
+        return pd.DataFrame(
+            columns=[
+                "Staff",
+                "referrals_processed",
+                "unique_referrers",
+                "unique_branches",
+                "avg_referrer_score",
+                "Multiplier Score",
+            ]
+        )
+
+    influence_lookup = referrer_metrics.set_index("Referrer")["Influence Score"]
+
+    staff = (
+        scored_df.groupby("Staff")
+        .agg(
+            referrals_processed=("New Account", "count"),
+            unique_referrers=("Referrer", "nunique"),
+            unique_branches=("Branch Code", "nunique"),
+        )
+        .reset_index()
+    )
+
+    staff["avg_referrer_score"] = (
+        scored_df.groupby("Staff")["Referrer"]
+        .apply(lambda refs: influence_lookup.reindex(refs.unique(), fill_value=0).mean())
+        .values
+    )
+
+    staff["Multiplier Score"] = weights.avg_referrer_score * _safe_minmax(
+        staff["avg_referrer_score"]
+    ) + weights.unique_referrers * _safe_minmax(staff["unique_referrers"])
+    staff["Multiplier Score"] = (staff["Multiplier Score"] * 100).round(1)
+    return staff
+
+
+def _safe_minmax(series: pd.Series) -> pd.Series:
+    """Min-max normalize to 0-1. Returns 0.5 for constant series."""
+    min_val, max_val = series.min(), series.max()
+    if max_val - min_val == 0:
+        return pd.Series(0.5, index=series.index)
+    return (series - min_val) / (max_val - min_val)

--- a/ics_toolkit/referral/temporal.py
+++ b/ics_toolkit/referral/temporal.py
@@ -1,0 +1,33 @@
+"""Layer 3: Temporal signal analysis for referral data."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+if TYPE_CHECKING:
+    from ics_toolkit.settings import ReferralSettings
+
+
+def add_temporal_signals(df: pd.DataFrame, settings: "ReferralSettings") -> pd.DataFrame:
+    """Add time-based signals to the enriched referral DataFrame.
+
+    Added columns: Days Since Last Referral, Is Burst, Days Since Latest, Is New Referrer
+    """
+    df = df.sort_values(["Referrer", "Issue Date"]).copy()
+
+    df["Days Since Last Referral"] = df.groupby("Referrer")["Issue Date"].diff().dt.days
+
+    df["Is Burst"] = df["Days Since Last Referral"].between(0, settings.burst_window_days)
+
+    max_date = df["Issue Date"].max()
+    if pd.notna(max_date):
+        df["Days Since Latest"] = (max_date - df["Issue Date"]).dt.days
+        first_dates = df.groupby("Referrer")["Issue Date"].transform("min")
+        df["Is New Referrer"] = (max_date - first_dates).dt.days <= settings.emerging_lookback_days
+    else:
+        df["Days Since Latest"] = pd.NA
+        df["Is New Referrer"] = False
+
+    return df

--- a/plans/feat-referral-intelligence-engine.md
+++ b/plans/feat-referral-intelligence-engine.md
@@ -1,0 +1,1107 @@
+# feat: Referral Intelligence Engine
+
+> A separate pipeline within ICS Toolkit that analyzes credit union referral data files to produce repeatable influence scoring, network inference, and staff multiplier reports.
+
+## Overview
+
+Add a new `referral` CLI subcommand and pipeline to ICS Toolkit that ingests a **separate referral data file** (distinct from the existing ICS analysis dump) and produces an **8-artifact intelligence report**. This is NOT an extension of the existing `ref_source.py` analyses -- it operates on a completely different dataset with its own columns, loader, and analytical layers.
+
+**Relationship to existing `ref_source.py` (ax73-ax80):**
+- `analyze` command examines **account-level** REF data from the ICS dump (balances, debit status, swipes)
+- `referral` command examines **referral-level** data from a separate tracking file (referrer identity, influence, timing)
+- They are **complementary**, not competing. CLI help text must clarify this distinction.
+
+**CLI:** `python -m ics_toolkit referral data/referral_file.xls`
+
+**Source file columns (8 fields):**
+
+| Column | Purpose | Null Handling |
+|--------|---------|---------------|
+| Referrer Name | Existing account holder who made the referral | Null -> grouped as `"UNKNOWN"`, included in staff/branch metrics, **excluded from influence scoring** |
+| Issue Date | Date the referral was issued | Null -> included in volume counts, **excluded from temporal analysis** (burst, velocity, recency) |
+| Referral Code | Raw code (decoded additively in Layer 3) | Null -> classified as `"MANUAL"` channel |
+| Purchase Manager | Staff member who processed the referral | Null -> grouped as `"UNASSIGNED"`, excluded from staff multiplier scoring |
+| Branch | Branch where referral was processed | Null -> grouped as `"UNKNOWN"`, excluded from branch density artifact |
+| Account Holder | New account holder (the referred person) | Null -> **log warning**, keep row (use MRDB hash as identifier) |
+| MRDB Account Hash | **Primary key** -- unique account ID | Null -> **raise DataError** (row is unusable without PK) |
+| Cert ID | Certificate identifier -- confirms completion | **Validation only**: warn if missing, but never used in analysis or scoring |
+
+**Duplicate MRDB handling:** Per data model rules, each row = one completed event. If the same MRDB Account Hash appears multiple times with different Cert IDs, these are **distinct events** (e.g., different products). If same MRDB + same Cert ID, log a warning but keep all rows (do NOT deduplicate).
+
+**Critical data model rules (from issue #4):**
+- Each row = one **completed** new account (not a lead or submission)
+- Cert ID confirms completion -- every row must have one
+- MRDB Account Hash confirms uniqueness per Account Holder
+- Do NOT merge or deduplicate rows -- treat each as a completed event
+- Do NOT infer leads, funnels, or drop-offs
+
+**Output artifacts (8 repeatable reports):**
+1. Top Referrers (influence-ranked, configurable N, default 25)
+2. Emerging Referrers (new + accelerating, not just bursting)
+3. Dormant High-Value Referrers (configurable thresholds)
+4. One-time vs Repeat Referrers (binary split comparison table)
+5. Staff as Multipliers (processing reach, NOT influence)
+6. Branch-level Influence Density (avg influence score of referrers routed through branch)
+7. Referral Code Health Report (channel distribution + reliability %)
+8. Overview KPIs (summary metrics, runs last, receives prior results)
+
+**Non-negotiable influence rules:**
+- Referrer Name = influence (only referrers can be ranked as influencers)
+- Purchase Manager = processing only (never ranked as influencer)
+- Branch = routing only (branch volume != growth; "branch density" measures avg referrer quality routed there, NOT branch production)
+- Influence rewards: multiple distinct Account Holders, repeat behavior, sustained presence, network activation
+- Influence does NOT reward: staff assignment, branch volume, single referrals
+
+---
+
+## Problem Statement / Motivation
+
+The existing `ref_source.py` (ax73-ax80) analyzes REF-sourced accounts **within the ICS data dump** -- it answers "how do REF accounts compare to DM accounts?" But it cannot answer deeper questions like:
+
+- **Who actually causes people to open accounts?** (influence scoring)
+- **Which referrers are emerging vs dormant?** (temporal analysis)
+- **Which staff amplify influence vs just process volume?** (multiplier scoring)
+- **Are referrals coming from households/networks?** (network inference)
+- **Which referral codes are signal vs noise?** (code health)
+
+These questions require the **raw referral file** with referrer-level detail that does not exist in the ICS dump.
+
+---
+
+## Resolved Design Decisions
+
+These were identified as gaps during SpecFlow analysis and are now resolved:
+
+| # | Question | Decision |
+|---|----------|----------|
+| 1 | Duplicate MRDB Account Hash handling | Keep all rows; warn if same MRDB + same Cert ID. Each row = completed event. |
+| 2 | NaN in Referrer Name | Group as `"UNKNOWN"`, include in staff/branch metrics, exclude from influence scoring |
+| 3 | NaN in Issue Date | Include in volume counts, exclude from temporal analysis (burst, velocity, recency) |
+| 4 | `.xls` loading strategy | `.xls` -> `engine="xlrd"`, `.xlsx` -> `engine="openpyxl"`, `.csv` -> `pd.read_csv()` |
+| 5 | Dormant threshold | No referral in last `dormancy_days` (default 180), configurable in config.yaml |
+| 6 | High-value threshold | `high_value_min_referrals` (default 5) unique accounts historically, configurable |
+| 7 | NaN velocity for single-referral referrers | `avg_days_between.fillna(0)` before scoring; velocity component = 0 |
+| 8 | Influence weights configurable? | Yes, via `referral.scoring_weights` in config.yaml. Logged at pipeline start for auditability. |
+| 9 | Alias table format | Config-driven: `referral.name_aliases: {"J SMITH": "JOHN SMITH"}` in config.yaml. V1 = strip+uppercase only. |
+| 10 | Layer numbering | Renumber to match execution order: L1=normalize, L2=decode, L3=temporal, L4=network, L5=scoring, L6=artifacts |
+| 11 | Cert ID usage | Validation only: warn if missing. Not used in any analysis, scoring, or artifact. |
+| 12 | Top N referrers | Configurable via `referral.top_n_referrers` (default 25) |
+| 13 | min_max for constant series | Returns 0.5 for all values (not 0) to avoid zeroing entire score components |
+| 14 | Network inference output location | Surfaced as extra columns on Top Referrers artifact: "Network Size", "Network IDs" |
+| 15 | Chart-to-artifact mapping | R01, R02, R05, R06, R07 get charts (5 total). R03, R04, R08 are table-only. |
+| 16 | Code prefix map per-client | Config-driven with hardcoded defaults; `referral.code_prefix_map` in config.yaml |
+| 17 | Emerging vs bursting | Emerging = first appeared within `emerging_lookback_days` (default 180) + burst_count >= 2 |
+| 18 | PPTX template | Reuse existing `templates/Template12.25.pptx` |
+| 19 | Output file naming | `{client_id}_Referral_Intelligence_{date}.xlsx` / `.pptx` |
+| 20 | Exception hierarchy | Reuse existing `DataError`, `AnalysisError`, `ExportError` from `exceptions.py` |
+
+---
+
+## QA / Validation Checklist (Built Into Pipeline)
+
+Per issue #4, the pipeline must enforce these checks:
+
+### Data Integrity (run at load time)
+- [ ] Every row has a MRDB Account Hash (raise `DataError` if missing)
+- [ ] Every row has a Cert ID (log warning if missing, continue)
+- [ ] No future dates in Issue Date (log warning, keep rows)
+- [ ] Duplicate MRDB + Cert ID pairs logged as warnings
+
+### Logic Validation (run after scoring)
+- [ ] Removing one Branch does not change top referrers materially
+- [ ] High-volume staff are NOT automatically top influencers
+- [ ] Referrers with only a single referral do NOT appear in "Top Referrers"
+- [ ] Staff multiplier top 5 != referral volume top 5 (if they match, weights are wrong)
+
+### Sanity Checks (logged as warnings)
+- [ ] Can point to specific referrers with repeat entries
+- [ ] Clustered referrals correspond to the same referrer
+- [ ] Influence conclusions are explainable using only source fields
+- [ ] Analysis would give the same answer next month (deterministic)
+
+### Failure Modes to Guard Against
+- Ranking Purchase Managers as influencers (explicitly prevented)
+- Treating Branch volume as growth (branch = routing only)
+- Ignoring Referral Code structure (decoded in Layer 2)
+- Mixing operational throughput with influence (separate scoring systems)
+- Changing definitions mid-analysis (config-locked weights)
+- NaN propagation in scoring (all NaN handling defined per-column)
+
+### Pass/Fail Standard
+> "A small set of existing account holders consistently generate new accounts across time, independent of staff or branch assignment."
+>
+> If the analysis cannot demonstrate this with evidence from the file, the build is incomplete.
+
+---
+
+## Proposed Solution
+
+### Architecture: Parallel Pipeline
+
+```
+ics_toolkit/
+  referral/                          # NEW -- entire package
+    __init__.py                      # run_referral() convenience function
+    pipeline.py                      # ReferralPipelineResult, run_pipeline(), export_outputs()
+    data_loader.py                   # load_referral_data() -- validates 8 required columns
+    column_map.py                    # REQUIRED_COLUMNS, COLUMN_ALIASES for referral file
+    normalizer.py                    # Layer 1: entity normalization (names, branches)
+    code_decoder.py                  # Layer 2: referral code decoding + tagging
+    temporal.py                      # Layer 3: burst detection, decay, lag analysis
+    network.py                       # Layer 4: household/network inference via soft signals
+    scoring.py                       # Layer 5: influence score + staff multiplier formulas
+    analyses/
+      __init__.py                    # REFERRAL_ANALYSIS_REGISTRY + run_all_referral_analyses()
+      base.py                        # ReferralContext dataclass (bundles df + metrics for analysis fns)
+      top_referrers.py               # R01: influence-ranked referrer table
+      emerging_referrers.py          # R02: momentum-based emerging referrers
+      dormant_referrers.py           # R03: dormant high-value referrers
+      onetime_vs_repeat.py           # R04: one-time vs repeat comparison table
+      staff_multipliers.py           # R05: staff multiplier scores
+      branch_density.py              # R06: branch-level influence density
+      code_health.py                 # R07: referral code health report
+      overview.py                    # R08: summary KPIs (runs last, receives prior_results)
+    charts/
+      __init__.py                    # REFERRAL_CHART_REGISTRY
+      top_referrers.py               # Horizontal bar: top N referrers by score
+      emerging_referrers.py          # Scatter timeline: referrer x date with burst markers
+      staff_multipliers.py           # Grouped bar: multiplier score vs volume
+      branch_density.py              # Vertical bar: avg influence score per branch
+      code_health.py                 # Stacked bar: code categories distribution
+    exports/
+      __init__.py
+      excel.py                       # Reuse analysis.exports.excel patterns
+      pptx.py                        # Reuse analysis.exports.pptx patterns + REFERRAL_SECTION_MAP
+  settings.py                        # MODIFY: add ReferralSettings as 3rd key
+  cli.py                             # MODIFY: add `referral` command
+  __init__.py                        # MODIFY: add run_referral() convenience
+tests/
+  referral/                          # NEW -- mirrors referral/ structure
+    __init__.py
+    conftest.py                      # Synthetic 8-column fixture (50+ rows, deterministic rng)
+    test_data_loader.py
+    test_normalizer.py
+    test_code_decoder.py
+    test_scoring.py
+    test_temporal.py
+    test_network.py
+    analyses/
+      __init__.py
+      test_top_referrers.py
+      test_emerging_referrers.py
+      test_dormant_referrers.py
+      test_onetime_vs_repeat.py
+      test_staff_multipliers.py
+      test_branch_density.py
+      test_code_health.py
+      test_overview.py
+    charts/
+      __init__.py
+      test_referral_charts.py
+    exports/
+      __init__.py
+      test_referral_excel.py
+      test_referral_pptx.py
+    test_pipeline.py
+    test_cli.py
+```
+
+### Key Design Decisions
+
+1. **Reuse `AnalysisResult`** from `analysis.analyses.base` -- same dataclass for all artifacts. This lets us reuse the Excel/PPTX exporters with minimal modifications.
+
+2. **Separate `referral/` package** -- not bolted onto `analysis/analyses/`. The data model, loader, and pipeline are fundamentally different. Clean separation prevents coupling.
+
+3. **MRDB Account Hash is the primary key** -- bridges to ODD and Tran files. Used for `nunique` counts in all "unique accounts" metrics.
+
+4. **Config-driven scoring weights** -- all weights and thresholds live in `config.yaml` under `referral:`, validated by Pydantic with sensible defaults. Logged at pipeline start for audit trail.
+
+5. **Layer numbering matches execution order** (L1-L6), not the conceptual framework's numbering.
+
+6. **ReferralContext dataclass** bundles `(df, referrer_metrics, staff_metrics, settings)` for clean analysis function signatures (avoids 5+ positional params).
+
+---
+
+## Technical Approach
+
+### Phase 1: Foundation (Settings, CLI, Data Loader)
+
+#### 1.1 ReferralSettings (modify `settings.py`)
+
+```python
+class ReferralScoringWeights(BaseModel):
+    """Influence score component weights. Must sum to 1.0."""
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    unique_accounts: float = 0.35
+    burst_count: float = 0.25
+    channels_used: float = 0.20
+    velocity: float = 0.10
+    longevity: float = 0.10
+
+    @model_validator(mode="after")
+    def check_weights_sum(self) -> "ReferralScoringWeights":
+        total = (self.unique_accounts + self.burst_count + self.channels_used
+                 + self.velocity + self.longevity)
+        if abs(total - 1.0) > 1e-6:
+            raise ValueError(f"Scoring weights must sum to 1.0, got {total:.4f}")
+        return self
+
+
+class ReferralStaffWeights(BaseModel):
+    """Staff multiplier score component weights. Must sum to 1.0."""
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    avg_referrer_score: float = 0.60
+    unique_referrers: float = 0.40
+
+    @model_validator(mode="after")
+    def check_weights_sum(self) -> "ReferralStaffWeights":
+        total = self.avg_referrer_score + self.unique_referrers
+        if abs(total - 1.0) > 1e-6:
+            raise ValueError(f"Staff weights must sum to 1.0, got {total:.4f}")
+        return self
+
+
+class ReferralSettings(BaseModel):
+    """Settings for the referral intelligence pipeline."""
+    model_config = ConfigDict(extra="forbid")
+
+    data_file: Path | None = None
+    client_id: str | None = None
+    client_name: str | None = None
+    output_dir: Path = Path("output/referral/")
+    outputs: OutputConfig = OutputConfig()
+    charts: ChartConfig = ChartConfig()
+    pptx_template: Path | None = DEFAULT_PPTX_TEMPLATE
+
+    # Scoring
+    scoring_weights: ReferralScoringWeights = ReferralScoringWeights()
+    staff_weights: ReferralStaffWeights = ReferralStaffWeights()
+
+    # Thresholds
+    burst_window_days: int = 14
+    dormancy_days: int = 180
+    high_value_min_referrals: int = 5
+    emerging_min_burst_count: int = 2
+    emerging_lookback_days: int = 180
+    top_n_referrers: int = 25
+
+    # Entity normalization
+    name_aliases: dict[str, str] = Field(default_factory=dict)
+    branch_mapping: dict[str, str] | None = None
+
+    # Code decoding (prefix -> channel mapping)
+    code_prefix_map: dict[str, str] = Field(default_factory=lambda: {
+        "150A": "BRANCH_STANDARD",
+        "120A": "BRANCH_STANDARD",
+        "080A": "BRANCH_STANDARD",
+        "100A": "BRANCH_STANDARD",
+        "030A": "BRANCH_STANDARD",
+        "020A": "BRANCH_STANDARD",
+        "PC": "DIGITAL_PROCESS",
+        "EMAIL": "EMAIL",
+    })
+
+    # Header row (for files with metadata rows above the actual header)
+    header_row: int = 0
+
+
+# Settings class gains third top-level key:
+class Settings(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    append: AppendSettings = AppendSettings()
+    analysis: AnalysisSettings = AnalysisSettings()
+    referral: ReferralSettings = ReferralSettings()  # NEW
+
+    # Existing from_yaml, for_append, for_analysis methods unchanged
+
+    @classmethod
+    def for_referral(cls, data_file: Path, **kwargs) -> "Settings":
+        """Create settings for referral-only usage."""
+        try:
+            return cls(referral=ReferralSettings(data_file=data_file, **kwargs))
+        except Exception as e:
+            raise ConfigError(f"Configuration error: {e}") from e
+```
+
+#### 1.2 CLI Subcommand (modify `cli.py`)
+
+```python
+@app.command()
+def referral(
+    data_file: Path = typer.Argument(..., help="Path to the referral data file (.xls/.xlsx/.csv)."),
+    config: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", "-c"),
+    output_dir: Path = typer.Option(None, "--output", "-o"),
+    client_id: str = typer.Option(None, "--client-id"),
+    client_name: str = typer.Option(None, "--client-name"),
+    no_charts: bool = typer.Option(False, "--no-charts"),
+    verbose: bool = typer.Option(False, "--verbose", "-v"),
+) -> None:
+    """Run referral intelligence analysis and generate reports.
+
+    Analyzes a referral tracking file to produce influence scoring,
+    staff multiplier scores, network inference, and code health reports.
+
+    NOTE: This is separate from `ics-toolkit analyze`, which examines
+    account-level data from the ICS dump. The referral command examines
+    referral-level data from a separate tracking file.
+    """
+    _setup_logging(verbose)
+    from ics_toolkit.referral.pipeline import export_outputs, run_pipeline
+    settings = _load_settings(config, referral={"data_file": str(data_file), ...})
+    result = run_pipeline(settings.referral, skip_charts=no_charts)
+    paths = export_outputs(result, skip_charts=no_charts)
+    for p in paths:
+        typer.echo(f"  {p}")
+```
+
+#### 1.3 Data Loader (`referral/data_loader.py`)
+
+```python
+REQUIRED_COLUMNS = [
+    "Referrer Name",
+    "Issue Date",
+    "Referral Code",
+    "Purchase Manager",
+    "Branch",
+    "Account Holder",
+    "MRDB Account Hash",
+    "Cert ID",
+]
+
+COLUMN_ALIASES = {
+    "referrer": "Referrer Name",
+    "referrer_name": "Referrer Name",
+    "referrer name": "Referrer Name",
+    "issue_date": "Issue Date",
+    "issue date": "Issue Date",
+    "date": "Issue Date",
+    "referral_code": "Referral Code",
+    "referral code": "Referral Code",
+    "code": "Referral Code",
+    "purchase_manager": "Purchase Manager",
+    "purchase manager": "Purchase Manager",
+    "staff": "Purchase Manager",
+    "branch": "Branch",
+    "branch_id": "Branch",
+    "account_holder": "Account Holder",
+    "account holder": "Account Holder",
+    "new_account": "Account Holder",
+    "mrdb_account_hash": "MRDB Account Hash",
+    "mrdb account hash": "MRDB Account Hash",
+    "mrdb": "MRDB Account Hash",
+    "account_hash": "MRDB Account Hash",
+    "cert_id": "Cert ID",
+    "cert id": "Cert ID",
+    "certificate_id": "Cert ID",
+}
+
+
+def load_referral_data(settings: ReferralSettings) -> pd.DataFrame:
+    """Load and validate referral data file.
+
+    Steps:
+    1. Detect format by suffix: .xls -> xlrd, .xlsx -> openpyxl, .csv -> pd.read_csv
+    2. Read with header_row offset (settings.header_row, default 0)
+    3. Resolve column aliases (case-insensitive, underscore-normalized)
+    4. Validate all REQUIRED_COLUMNS present
+    5. Drop rows where MRDB Account Hash is null (raise DataError if ALL null)
+    6. Warn on rows with null Cert ID
+    7. Parse Issue Date as datetime (errors="coerce"), warn on NaT count
+    8. Warn on future dates in Issue Date
+    9. Log duplicate MRDB + Cert ID pairs
+    10. Return validated DataFrame
+    """
+```
+
+**Files to create/modify:**
+- `ics_toolkit/referral/__init__.py`
+- `ics_toolkit/referral/data_loader.py`
+- `ics_toolkit/referral/column_map.py`
+- Modify: `ics_toolkit/settings.py` (add `ReferralSettings`, `ReferralScoringWeights`, `ReferralStaffWeights`)
+- Modify: `ics_toolkit/cli.py` (add `referral` command)
+- Modify: `ics_toolkit/__init__.py` (add `run_referral()`)
+- `tests/referral/__init__.py`
+- `tests/referral/conftest.py` (synthetic fixture)
+- `tests/referral/test_data_loader.py`
+- `tests/referral/test_cli.py`
+
+---
+
+### Phase 2: Core Engine (Layers 1-5)
+
+#### 2.1 Layer 1 -- Entity Normalizer (`referral/normalizer.py`)
+
+```python
+def normalize_entities(df: pd.DataFrame, settings: ReferralSettings) -> pd.DataFrame:
+    """Standardize entity names. Adds canonical columns without overwriting originals.
+
+    Name normalization rules:
+    - Strip whitespace, collapse multiple spaces
+    - Uppercase
+    - Apply alias table if configured
+    - NaN/blank -> sentinel value per column (see null handling table)
+
+    Surname extraction:
+    - Split on whitespace, take last token
+    - Guard: skip suffixes ["JR", "SR", "II", "III", "IV"] -> take second-to-last
+    - Guard: single-word names -> surname = full name
+    - Guard: NaN -> surname = "UNKNOWN"
+    """
+    df = df.copy()
+    df["Referrer"] = _normalize_name(df["Referrer Name"], settings.name_aliases, null_sentinel="UNKNOWN")
+    df["New Account"] = _normalize_name(df["Account Holder"], settings.name_aliases, null_sentinel="UNKNOWN")
+    df["Staff"] = _normalize_name(df["Purchase Manager"], settings.name_aliases, null_sentinel="UNASSIGNED")
+    df["Branch Code"] = df["Branch"].fillna("UNKNOWN").astype(str).str.strip()
+
+    if settings.branch_mapping:
+        df["Branch Label"] = df["Branch Code"].map(settings.branch_mapping).fillna(df["Branch Code"])
+    else:
+        df["Branch Label"] = df["Branch Code"]
+
+    # Extract surnames for network inference
+    df["Referrer Surname"] = _extract_surname(df["Referrer"])
+    df["Account Surname"] = _extract_surname(df["New Account"])
+    return df
+
+
+SUFFIXES = frozenset({"JR", "SR", "II", "III", "IV", "V"})
+
+def _extract_surname(series: pd.Series) -> pd.Series:
+    """Extract surname from full name, skipping common suffixes."""
+    def _surname(name: str) -> str:
+        parts = name.split()
+        if len(parts) <= 1:
+            return name
+        if parts[-1] in SUFFIXES and len(parts) > 2:
+            return parts[-2]
+        return parts[-1]
+    return series.apply(_surname)
+
+
+def _normalize_name(series: pd.Series, aliases: dict, null_sentinel: str) -> pd.Series:
+    """Strip, uppercase, collapse spaces, apply alias table."""
+    import re
+    normalized = series.fillna(null_sentinel).astype(str).str.strip().str.upper()
+    normalized = normalized.apply(lambda n: re.sub(r"\s+", " ", n))
+    normalized = normalized.replace("", null_sentinel)
+    if aliases:
+        upper_aliases = {k.upper(): v.upper() for k, v in aliases.items()}
+        normalized = normalized.map(lambda n: upper_aliases.get(n, n))
+    return normalized
+```
+
+#### 2.2 Layer 2 -- Code Decoder (`referral/code_decoder.py`)
+
+```python
+def decode_referral_codes(df: pd.DataFrame, settings: ReferralSettings) -> pd.DataFrame:
+    """Decode referral codes into channel, type, reliability tags.
+
+    Classification hierarchy (checked in order):
+    1. NaN / blank / whitespace-only / "None" string -> "MANUAL"
+    2. Config prefix map match (longest prefix first)
+    3. Contains "EMAIL" (case-insensitive) -> "EMAIL"
+    4. Fallback -> "OTHER"
+
+    Added columns: Referral Channel, Referral Type, Referral Reliability
+    """
+    df = df.copy()
+    # Sort prefixes by length descending for longest-match-first
+    sorted_prefixes = sorted(settings.code_prefix_map.keys(), key=len, reverse=True)
+    df["Referral Channel"] = df["Referral Code"].apply(
+        lambda c: _classify_channel(c, sorted_prefixes, settings.code_prefix_map)
+    )
+    df["Referral Type"] = df["Referral Channel"].map({
+        "BRANCH_STANDARD": "Standard",
+        "DIGITAL_PROCESS": "Standard",
+        "EMAIL": "Standard",
+        "MANUAL": "Manual",
+        "OTHER": "Exception",
+    }).fillna("Exception")
+    df["Referral Reliability"] = df["Referral Type"].map({
+        "Standard": "High", "Manual": "Medium", "Exception": "Low",
+    })
+    return df
+
+
+def _classify_channel(code, sorted_prefixes, prefix_map):
+    """Classify a single referral code."""
+    if pd.isna(code) or str(code).strip() in ("", "None", "none", "NONE"):
+        return "MANUAL"
+    code_str = str(code).strip().upper()
+    for prefix in sorted_prefixes:
+        if code_str.startswith(prefix.upper()):
+            return prefix_map[prefix]
+    if "EMAIL" in code_str:
+        return "EMAIL"
+    return "OTHER"
+```
+
+#### 2.3 Layer 3 -- Temporal Analysis (`referral/temporal.py`)
+
+```python
+def add_temporal_signals(df: pd.DataFrame, settings: ReferralSettings) -> pd.DataFrame:
+    """Add time-based signals: inter-referral gap, burst flag, recency.
+
+    Only operates on rows where Issue Date is not NaT.
+    Rows with NaT Issue Date get NaN for all temporal columns.
+    """
+    df = df.sort_values(["Referrer", "Issue Date"]).copy()
+
+    # Inter-referral gap (days since previous referral by same referrer)
+    df["Days Since Last Referral"] = df.groupby("Referrer")["Issue Date"].diff().dt.days
+
+    # Burst flag: referrals within configurable window
+    df["Is Burst"] = df["Days Since Last Referral"].between(0, settings.burst_window_days)
+
+    # Recency: days from each referral to the max date in dataset
+    max_date = df["Issue Date"].max()
+    df["Days Since Latest"] = (max_date - df["Issue Date"]).dt.days
+
+    # First appearance (for emerging referrer detection)
+    first_dates = df.groupby("Referrer")["Issue Date"].transform("min")
+    df["Is New Referrer"] = (max_date - first_dates).dt.days <= settings.emerging_lookback_days
+
+    return df
+```
+
+#### 2.4 Layer 4 -- Network Inference (`referral/network.py`)
+
+```python
+def infer_networks(df: pd.DataFrame) -> pd.DataFrame:
+    """Soft household/network inference via shared referrer + account surname.
+
+    A "network" is a (Referrer, Account Surname) pair. This is intentionally
+    conservative -- requires TWO corroborating signals (same referrer AND
+    same surname) to infer a household connection.
+
+    Added columns: Network ID, Network Size
+    """
+    df = df.copy()
+    network_map = (
+        df.groupby(["Referrer", "Account Surname"])
+        .agg(network_size=("MRDB Account Hash", "nunique"))
+        .reset_index()
+    )
+    network_map["Network ID"] = network_map["Referrer"] + ":" + network_map["Account Surname"]
+    df = df.merge(
+        network_map[["Referrer", "Account Surname", "Network ID", "network_size"]],
+        on=["Referrer", "Account Surname"], how="left",
+    )
+    df.rename(columns={"network_size": "Network Size"}, inplace=True)
+    return df
+```
+
+#### 2.5 Layer 5 -- Scoring (`referral/scoring.py`)
+
+```python
+def compute_referrer_metrics(df: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate per-referrer metrics for influence scoring.
+
+    Excludes referrers where Referrer == "UNKNOWN" (null referrer names).
+    """
+    scored_df = df[df["Referrer"] != "UNKNOWN"].copy()
+    metrics = scored_df.groupby("Referrer").agg(
+        total_referrals=("New Account", "count"),
+        unique_accounts=("MRDB Account Hash", "nunique"),
+        active_days=("Issue Date", lambda x: (x.max() - x.min()).days + 1 if x.notna().any() else 0),
+        burst_count=("Is Burst", "sum"),
+        avg_days_between=("Days Since Last Referral", "mean"),
+        channels_used=("Referral Channel", "nunique"),
+        branches_used=("Branch Code", "nunique"),
+        first_referral=("Issue Date", "min"),
+        last_referral=("Issue Date", "max"),
+        network_count=("Network ID", "nunique"),
+        max_network_size=("Network Size", "max"),
+    ).reset_index()
+    return metrics
+
+
+def compute_influence_scores(
+    metrics: pd.DataFrame,
+    weights: "ReferralScoringWeights",
+) -> pd.DataFrame:
+    """Weighted composite influence score (0-100).
+
+    Weights are logged for auditability. Version is derived from weight values.
+    NaN in avg_days_between (single-referral) filled with 0 before scoring.
+    """
+    m = metrics.copy()
+    m["avg_days_between"] = m["avg_days_between"].fillna(0)
+
+    m["score"] = (
+        weights.unique_accounts * _safe_minmax(m["unique_accounts"])
+        + weights.burst_count * _safe_minmax(m["burst_count"])
+        + weights.channels_used * _safe_minmax(m["channels_used"])
+        + weights.velocity * _safe_minmax(1 / (m["avg_days_between"] + 1))
+        + weights.longevity * _safe_minmax(m["active_days"])
+    )
+    m["Influence Score"] = (_safe_minmax(m["score"]) * 100).round(1)
+    return m
+
+
+def compute_staff_multipliers(
+    df: pd.DataFrame,
+    referrer_metrics: pd.DataFrame,
+    weights: "ReferralStaffWeights",
+) -> pd.DataFrame:
+    """Staff multiplier: amplification vs volume.
+
+    Excludes staff where Staff == "UNASSIGNED".
+    Uses safe reindex to handle referrers missing from metrics (e.g., UNKNOWN).
+    """
+    scored_df = df[df["Staff"] != "UNASSIGNED"].copy()
+    influence_lookup = referrer_metrics.set_index("Referrer")["Influence Score"]
+
+    staff = scored_df.groupby("Staff").agg(
+        referrals_processed=("New Account", "count"),
+        unique_referrers=("Referrer", "nunique"),
+        unique_branches=("Branch Code", "nunique"),
+    ).reset_index()
+
+    # Safe lookup: reindex with fill_value=0 for missing referrers
+    staff["avg_referrer_score"] = scored_df.groupby("Staff")["Referrer"].apply(
+        lambda refs: influence_lookup.reindex(refs.unique(), fill_value=0).mean()
+    ).values
+
+    staff["Multiplier Score"] = (
+        weights.avg_referrer_score * _safe_minmax(staff["avg_referrer_score"])
+        + weights.unique_referrers * _safe_minmax(staff["unique_referrers"])
+    )
+    staff["Multiplier Score"] = (staff["Multiplier Score"] * 100).round(1)
+    return staff
+
+
+def _safe_minmax(series: pd.Series) -> pd.Series:
+    """Min-max normalize to 0-1. Returns 0.5 for constant series."""
+    min_val, max_val = series.min(), series.max()
+    if max_val - min_val == 0:
+        return pd.Series(0.5, index=series.index)
+    return (series - min_val) / (max_val - min_val)
+```
+
+**Files:**
+- `ics_toolkit/referral/normalizer.py`
+- `ics_toolkit/referral/code_decoder.py`
+- `ics_toolkit/referral/temporal.py`
+- `ics_toolkit/referral/scoring.py`
+- `ics_toolkit/referral/network.py`
+- `tests/referral/test_normalizer.py`
+- `tests/referral/test_code_decoder.py`
+- `tests/referral/test_temporal.py`
+- `tests/referral/test_scoring.py`
+- `tests/referral/test_network.py`
+
+---
+
+### Phase 3: Analysis Artifacts (Layer 6)
+
+Each artifact follows the existing `AnalysisResult` pattern. Analysis functions receive a `ReferralContext` dataclass:
+
+```python
+@dataclass
+class ReferralContext:
+    """Bundles all pre-computed data for analysis functions."""
+    df: pd.DataFrame               # Full enriched DataFrame (all layers applied)
+    referrer_metrics: pd.DataFrame  # Per-referrer metrics + influence scores
+    staff_metrics: pd.DataFrame     # Per-staff metrics + multiplier scores
+    settings: ReferralSettings
+```
+
+**Analysis function signature:** `def analyze_<name>(ctx: ReferralContext) -> AnalysisResult`
+
+**Exception:** `analyze_overview` takes an extra `prior_results: list[AnalysisResult]` kwarg.
+
+#### Artifact Definitions
+
+| # | Artifact | Module | Sheet Name | Key Columns | Chart? |
+|---|----------|--------|------------|-------------|--------|
+| R01 | Top Referrers | `top_referrers.py` | `R01_Top_Referrers` | Referrer, Influence Score, Unique Accounts, Total Referrals, Burst Count, Channels, Network Size | Horizontal bar |
+| R02 | Emerging Referrers | `emerging_referrers.py` | `R02_Emerging` | Referrer, Influence Score, Burst Count, Days Active, First Referral, Last Referral | Scatter timeline |
+| R03 | Dormant High-Value | `dormant_referrers.py` | `R03_Dormant` | Referrer, Historical Score, Total Referrals, Unique Accounts, Last Referral, Days Dormant | None |
+| R04 | One-time vs Repeat | `onetime_vs_repeat.py` | `R04_Repeat` | Category (One-time/Repeat), Count, %, Avg Unique Accounts, Avg Influence Score, Avg Active Days | None |
+| R05 | Staff Multipliers | `staff_multipliers.py` | `R05_Staff` | Staff, Multiplier Score, Referrals Processed, Unique Referrers, Avg Referrer Score, Unique Branches | Grouped bar |
+| R06 | Branch Density | `branch_density.py` | `R06_Branch` | Branch, Total Referrals, Unique Referrers, Avg Influence Score, Top Referrer, Channel Mix | Vertical bar |
+| R07 | Code Health | `code_health.py` | `R07_Code_Health` | Channel, Type, Reliability, Count, %, Known Code % | Stacked bar |
+| R08 | Overview KPIs | `overview.py` | `R08_Overview` | Metric, Value | None |
+
+#### Detailed Artifact Specifications
+
+**R04 -- One-time vs Repeat Referrers** (new definition):
+- Answers: "What proportion of referrers are one-time vs repeat, and how do they differ?"
+- One-time = referrer with exactly 1 referral; Repeat = referrer with 2+ referrals
+- Output: 2-row comparison table with Grand Total row
+- Columns: Category, Count, % of Total, Avg Unique Accounts, Avg Influence Score, Avg Active Days
+- Uses `append_grand_total_row()` from `analysis.analyses.templates`
+
+**R08 -- Overview KPIs** (new definition):
+- Answers: "What are the headline numbers for this referral program?"
+- Runs last, receives `prior_results` for cross-artifact stats
+- Output: KPI table (Metric, Value) with ~15 rows:
+  - Total Referrals
+  - Unique Referrers
+  - Unique New Accounts
+  - Repeat Referrer %
+  - Avg Referrals per Referrer
+  - Top Referrer Influence Score
+  - Median Influence Score
+  - Avg Days Between Referrals
+  - Burst Referral %
+  - Staff with Highest Multiplier
+  - Most Active Branch
+  - Dominant Referral Channel
+  - Manual Code %
+  - Exception Code %
+  - Avg Network Size
+- Uses `kpi_summary()` from `analysis.analyses.templates`
+
+**R02 -- Emerging Referrers** (clarified):
+- "Emerging" = first referral within `emerging_lookback_days` (default 180) AND `burst_count >= emerging_min_burst_count` (default 2)
+- This separates "new and accelerating" from "old and bursting" (old bursters appear in R01 Top Referrers instead)
+
+**R03 -- Dormant High-Value Referrers** (clarified):
+- "Dormant" = no referral in last `dormancy_days` (default 180)
+- "High-Value" = `unique_accounts >= high_value_min_referrals` (default 5) OR historical influence score in top quartile
+- Ordered by historical influence score descending
+
+**R06 -- Branch Density** (clarified):
+- "Branch Influence Density" = average influence score of referrers routed through that branch
+- This does NOT reward branch volume -- it measures whether a branch handles high-quality referrers
+- Includes: Top Referrer (name of highest-scoring referrer at that branch), Channel Mix (% Standard/Manual/Exception)
+
+**Files:**
+- `ics_toolkit/referral/analyses/__init__.py`
+- `ics_toolkit/referral/analyses/base.py` (ReferralContext)
+- `ics_toolkit/referral/analyses/top_referrers.py`
+- `ics_toolkit/referral/analyses/emerging_referrers.py`
+- `ics_toolkit/referral/analyses/dormant_referrers.py`
+- `ics_toolkit/referral/analyses/onetime_vs_repeat.py`
+- `ics_toolkit/referral/analyses/staff_multipliers.py`
+- `ics_toolkit/referral/analyses/branch_density.py`
+- `ics_toolkit/referral/analyses/code_health.py`
+- `ics_toolkit/referral/analyses/overview.py`
+- `tests/referral/analyses/__init__.py`
+- `tests/referral/analyses/test_*.py` (one per module)
+
+---
+
+### Phase 4: Charts
+
+| Analysis | Chart Type | Description |
+|----------|-----------|-------------|
+| R01 Top Referrers | Horizontal bar | Top N by influence score, `config.colors[0]` fill |
+| R02 Emerging Referrers | Scatter timeline | Referrer (y) x Issue Date (x), marker size = burst count |
+| R05 Staff Multipliers | Grouped bar | Multiplier score (primary) vs volume (secondary axis) |
+| R06 Branch Density | Vertical bar | Avg influence score per branch, sorted descending |
+| R07 Code Health | Stacked bar | Code category distribution by Reliability tier |
+
+All chart functions follow existing pattern: `chart_<name>(df: pd.DataFrame, config: ChartConfig) -> go.Figure`.
+
+Uses same `BRAND_COLORS` from `settings.py`, same `LAYOUT_DEFAULTS` pattern (horizontal legend, 60/40 margins).
+
+```python
+# referral/charts/__init__.py
+REFERRAL_CHART_REGISTRY: dict[str, Callable] = {
+    "Top Referrers": chart_top_referrers,
+    "Emerging Referrers": chart_emerging_referrers,
+    "Staff Multipliers": chart_staff_multipliers,
+    "Branch Influence Density": chart_branch_density,
+    "Code Health Report": chart_code_health,
+}
+```
+
+**Files:**
+- `ics_toolkit/referral/charts/__init__.py`
+- `ics_toolkit/referral/charts/top_referrers.py`
+- `ics_toolkit/referral/charts/emerging_referrers.py`
+- `ics_toolkit/referral/charts/staff_multipliers.py`
+- `ics_toolkit/referral/charts/branch_density.py`
+- `ics_toolkit/referral/charts/code_health.py`
+- `tests/referral/charts/__init__.py`
+- `tests/referral/charts/test_referral_charts.py`
+
+---
+
+### Phase 5: Pipeline + Exports
+
+#### 5.1 Pipeline (`referral/pipeline.py`)
+
+```python
+@dataclass
+class ReferralPipelineResult:
+    settings: ReferralSettings
+    df: pd.DataFrame                     # Full enriched DataFrame
+    referrer_metrics: pd.DataFrame       # Per-referrer metrics + scores
+    staff_metrics: pd.DataFrame          # Per-staff metrics + scores
+    analyses: list[AnalysisResult]       # 8 artifacts
+    charts: dict[str, go.Figure]         # 5 charts
+    chart_pngs: dict[str, bytes]         # PNG renders
+
+
+def run_pipeline(
+    settings: ReferralSettings,
+    on_progress: Callable[[int, int, str], None] | None = None,
+    skip_charts: bool = False,
+) -> ReferralPipelineResult:
+    """Execute the referral intelligence pipeline.
+
+    Steps:
+    1. Load + validate data (data_loader.load_referral_data)
+    2. Layer 1: Entity normalization (normalizer.normalize_entities)
+    3. Layer 2: Code decoding (code_decoder.decode_referral_codes)
+    4. Layer 3: Temporal signals (temporal.add_temporal_signals)
+    5. Layer 4: Network inference (network.infer_networks)
+    6. Layer 5: Scoring (scoring.compute_referrer_metrics + compute_influence_scores + compute_staff_multipliers)
+    7. Log scoring weights for auditability
+    8. Build ReferralContext
+    9. Layer 6: Run all 8 analyses (REFERRAL_ANALYSIS_REGISTRY)
+    10. Charts (REFERRAL_CHART_REGISTRY) unless skip_charts
+    11. Render PNGs (reuse analysis.charts.renderer.render_all_chart_pngs)
+    12. Return ReferralPipelineResult
+    """
+
+
+def export_outputs(
+    result: ReferralPipelineResult,
+    skip_charts: bool = False,
+) -> list[Path]:
+    """Export pipeline results to files.
+
+    1. Write Excel report ({client_id}_Referral_Intelligence_{date}.xlsx)
+    2. Write PPTX report ({client_id}_Referral_Intelligence_{date}.pptx)
+    3. Save charts as HTML (optional)
+    Returns list of output file paths.
+    """
+```
+
+#### 5.2 Exports
+
+```python
+# referral/exports/excel.py
+# Reuse NamedStyle patterns from analysis.exports.excel
+# Same header, data_even, data_odd, total styles
+# Chart images embedded below data tables
+# Number formatting: '0.0"%"' for percentages, '#,##0' for counts, '0.0' for scores
+
+
+# referral/exports/pptx.py
+REFERRAL_SECTION_MAP = {
+    "Referral Intelligence Overview": ["Overview KPIs"],
+    "Referrer Influence": [
+        "Top Referrers",
+        "Emerging Referrers",
+        "Dormant High-Value Referrers",
+        "One-time vs Repeat Referrers",
+    ],
+    "Staff & Branch": [
+        "Staff Multipliers",
+        "Branch Influence Density",
+    ],
+    "Code Health": ["Code Health Report"],
+}
+```
+
+**Files:**
+- `ics_toolkit/referral/pipeline.py`
+- `ics_toolkit/referral/exports/__init__.py`
+- `ics_toolkit/referral/exports/excel.py`
+- `ics_toolkit/referral/exports/pptx.py`
+- `tests/referral/test_pipeline.py`
+- `tests/referral/exports/__init__.py`
+- `tests/referral/exports/test_referral_excel.py`
+- `tests/referral/exports/test_referral_pptx.py`
+
+---
+
+### Phase 6: Config + Integration
+
+- Update `config.example.yaml` with full `referral:` section and comments
+- Add `xlrd` to `requirements.txt` for `.xls` support
+- Verify existing `analyze` and `append` commands are unaffected (run full test suite)
+- Update `pyproject.toml` if needed
+
+---
+
+## Test Strategy
+
+### Test Fixtures (`tests/referral/conftest.py`)
+
+```python
+import numpy as np
+import pandas as pd
+import pytest
+from datetime import datetime
+
+REFERENCE_DATE = datetime(2026, 1, 15)
+
+REFERRERS = ["JOHN SMITH", "JANE DOE", "BOB WILSON", "ALICE BROWN", "TOM JONES",
+             "MARY CLARK", "DAVID HALL", "SARAH KING"]
+STAFF = ["SARAH MANAGER", "MIKE HANDLER", "LISA PROCESSOR"]
+BRANCHES = ["001", "002", "003"]
+CODES = ["150A001", "120A002", "PC100", None, "EMAIL_Q1", "080A003", None, "UNKNOWN_XYZ"]
+
+@pytest.fixture(scope="session")
+def rng():
+    return np.random.default_rng(42)
+
+@pytest.fixture
+def sample_referral_df(rng):
+    """50-row deterministic referral dataset with known patterns."""
+    n = 50
+    return pd.DataFrame({
+        "Referrer Name": rng.choice(REFERRERS, n),
+        "Issue Date": pd.date_range("2025-01-01", periods=n, freq="7D"),
+        "Referral Code": rng.choice(CODES, n),
+        "Purchase Manager": rng.choice(STAFF, n),
+        "Branch": rng.choice(BRANCHES, n),
+        "Account Holder": [f"NEW_ACCOUNT_{i}" for i in range(n)],
+        "MRDB Account Hash": [f"HASH_{i:04d}" for i in range(n)],
+        "Cert ID": [f"CERT_{i:04d}" for i in range(n)],
+    })
+
+@pytest.fixture
+def sample_referral_settings(tmp_path, sample_referral_df):
+    """Write sample data to tmp xlsx and create ReferralSettings."""
+    data_path = tmp_path / "test_referral.xlsx"
+    sample_referral_df.to_excel(data_path, index=False)
+    return ReferralSettings(data_file=data_path, output_dir=tmp_path / "output")
+
+@pytest.fixture
+def empty_referral_df():
+    """Empty DataFrame with correct columns for edge-case testing."""
+    return pd.DataFrame(columns=[...REQUIRED_COLUMNS...])
+```
+
+### Test Pattern Per Module
+
+Each test module follows class-based organization:
+
+```python
+class TestAnalyzeTopReferrers:
+    def test_returns_analysis_result(self, ctx):
+        result = analyze_top_referrers(ctx)
+        assert isinstance(result, AnalysisResult)
+        assert result.error is None
+
+    def test_has_expected_columns(self, ctx):
+        result = analyze_top_referrers(ctx)
+        assert "Referrer" in result.df.columns
+        assert "Influence Score" in result.df.columns
+
+    def test_sheet_name(self, ctx):
+        result = analyze_top_referrers(ctx)
+        assert result.sheet_name == "R01_Top_Referrers"
+
+    def test_respects_top_n(self, ctx):
+        result = analyze_top_referrers(ctx)
+        assert len(result.df) <= ctx.settings.top_n_referrers
+
+    def test_excludes_single_referral(self, ctx):
+        result = analyze_top_referrers(ctx)
+        assert (result.df["Total Referrals"] > 1).all()
+
+    def test_excludes_unknown_referrer(self, ctx):
+        result = analyze_top_referrers(ctx)
+        assert "UNKNOWN" not in result.df["Referrer"].values
+
+    def test_empty_input(self, empty_ctx):
+        result = analyze_top_referrers(empty_ctx)
+        assert isinstance(result, AnalysisResult)
+        assert len(result.df) == 0
+```
+
+### Edge Case Tests (across modules)
+
+- Single row input (1 referral, 1 referrer)
+- All same referrer (one person referred everyone)
+- All null referral codes (100% MANUAL channel)
+- All null Issue Dates (no temporal analysis possible)
+- Unicode in names (accented characters, CJK)
+- Very large input (parametrize with n=10000 for performance regression)
+- Future dates in Issue Date
+- Duplicate MRDB + Cert ID
+
+---
+
+## Acceptance Criteria
+
+### Functional
+- [ ] `python -m ics_toolkit referral data/file.xls` runs full pipeline, produces Excel + PPTX
+- [ ] All 8 analysis artifacts generate valid `AnalysisResult` objects
+- [ ] Entity normalization handles nulls, whitespace, case variations, suffixes (JR/SR)
+- [ ] Code decoder classifies codes using config-driven prefix map (longest match first)
+- [ ] Influence score is 0-100 weighted composite with configurable weights validated to sum to 1.0
+- [ ] Burst detection flags referrals within configurable window (default 14 days)
+- [ ] Network inference assigns Network IDs via shared referrer + surname
+- [ ] Staff multiplier distinguishes influence amplification from volume
+- [ ] `--no-charts`, `--output`, `--client-id`, `--client-name`, `--verbose` flags work
+- [ ] Existing `python -m ics_toolkit analyze` and `append` are unaffected
+- [ ] `.xls` (xlrd), `.xlsx` (openpyxl), and `.csv` formats all load correctly
+- [ ] Null MRDB Account Hash rows raise DataError; null in other columns handled gracefully
+- [ ] Scoring weights logged at pipeline start for auditability
+
+### Quality Gates
+- [ ] 90%+ test coverage on `referral/` package
+- [ ] All existing tests pass (976+ tests)
+- [ ] `ruff check` and `ruff format --check` clean
+
+---
+
+## Implementation Phases Summary
+
+| Phase | Scope | New Files | Modified | Est. Tests |
+|-------|-------|-----------|----------|-----------|
+| 1. Foundation | Settings, CLI, Data Loader | 8 | 3 | ~40 |
+| 2. Core Engine | Layers 1-5 (normalize, decode, temporal, network, scoring) | 5 | 0 | ~55 |
+| 3. Artifacts | 8 analysis modules + ReferralContext | 10 | 0 | ~55 |
+| 4. Charts | 5 chart builders + registry | 6 | 0 | ~20 |
+| 5. Pipeline + Exports | Orchestrator, Excel, PPTX | 6 | 0 | ~30 |
+| 6. Config | config.example.yaml, requirements.txt, pyproject.toml | 0 | 3 | ~5 |
+| **Total** | | **~35** | **~6** | **~205** |
+
+---
+
+## Risk Analysis
+
+| Risk | Mitigation |
+|------|------------|
+| Unknown referral code format | Generic prefix classifier with config override; refine with real data |
+| `.xls` binary format | Add `xlrd` dependency; detect format by suffix in data_loader |
+| Name normalization merges wrong people | V1 = exact match + alias table; fuzzy matching is future enhancement |
+| Scoring weights need tuning | All weights configurable via config.yaml, validated to sum to 1.0 |
+| Large files (50k+ rows) slow | Vectorized pandas ops throughout; no row-level loops except surname extraction |
+| NaN propagation in scoring | All NaN handling defined per-column (see null handling table in Overview) |
+| Single-referral velocity = NaN | fillna(0) before scoring; single-referral referrers excluded from Top Referrers |
+| Constant-series min-max = 0 | Returns 0.5 (midpoint) instead of 0 for constant series |
+| Staff score crash on missing referrer | Safe reindex with fill_value=0 |
+
+---
+
+## Dependencies
+
+**New:**
+- `xlrd` -- required for `.xls` (legacy Excel) file reading
+
+**Existing (no changes):**
+- `pandas`, `numpy`, `plotly`, `openpyxl`, `python-pptx`, `pydantic`, `pyyaml`, `typer`, `rich`
+
+---
+
+## References
+
+### Internal
+- Existing REF analysis (different data source): `ics_toolkit/analysis/analyses/ref_source.py`
+- Analysis registry pattern: `ics_toolkit/analysis/analyses/__init__.py`
+- AnalysisResult dataclass: `ics_toolkit/analysis/analyses/base.py`
+- Template helpers: `ics_toolkit/analysis/analyses/templates.py`
+- Excel export: `ics_toolkit/analysis/exports/excel.py`
+- PPTX export: `ics_toolkit/analysis/exports/pptx.py`
+- Settings: `ics_toolkit/settings.py`
+- Test fixtures: `tests/analysis/conftest.py`
+- Chart renderer: `ics_toolkit/analysis/charts/renderer.py`
+
+### Feature Spec
+- GitHub: `JG-CSI-Velocity/ics_toolkit/referral-file-analysis`
+- Issue #4: `JG-CSI-Velocity/ics_toolkit/issues/4` -- Build checklist with QA validation requirements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     "typer>=0.9",
     "rich>=13.0",
     "python-dateutil>=2.8",
+    "xlrd>=2.0",
+    "matplotlib>=3.7",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ pyyaml>=6.0
 typer>=0.9
 rich>=13.0
 python-dateutil>=2.8
+xlrd>=2.0
+matplotlib>=3.7

--- a/tests/referral/analyses/conftest.py
+++ b/tests/referral/analyses/conftest.py
@@ -1,0 +1,67 @@
+"""Shared fixtures for referral analysis artifact tests."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from ics_toolkit.referral.analyses.base import ReferralContext
+from ics_toolkit.referral.code_decoder import decode_referral_codes
+from ics_toolkit.referral.network import infer_networks
+from ics_toolkit.referral.normalizer import normalize_entities
+from ics_toolkit.referral.scoring import (
+    compute_influence_scores,
+    compute_referrer_metrics,
+    compute_staff_multipliers,
+)
+from ics_toolkit.referral.temporal import add_temporal_signals
+from ics_toolkit.settings import ReferralSettings
+
+
+@pytest.fixture
+def referral_context(sample_referral_df, sample_referral_settings):
+    """Fully-processed ReferralContext ready for analysis functions."""
+    df = sample_referral_df.copy()
+    settings = sample_referral_settings
+
+    # Run full pipeline: normalize -> decode -> temporal -> network -> scoring
+    df = normalize_entities(df, settings)
+    df = decode_referral_codes(df, settings)
+    df = add_temporal_signals(df, settings)
+    df = infer_networks(df)
+
+    metrics = compute_referrer_metrics(df)
+    metrics = compute_influence_scores(metrics, settings.scoring_weights)
+    staff = compute_staff_multipliers(df, metrics, settings.staff_weights)
+
+    return ReferralContext(
+        df=df,
+        referrer_metrics=metrics,
+        staff_metrics=staff,
+        settings=settings,
+    )
+
+
+@pytest.fixture
+def empty_context(sample_referral_settings):
+    """ReferralContext with empty DataFrames for edge-case testing."""
+    return ReferralContext(
+        df=pd.DataFrame(columns=[
+            "Referrer", "New Account", "Staff", "Branch Code",
+            "Issue Date", "MRDB Account Hash", "Referral Channel",
+            "Referral Type", "Referral Reliability",
+            "Days Since Last Referral", "Is Burst",
+            "Network ID", "Network Size",
+        ]),
+        referrer_metrics=pd.DataFrame(columns=[
+            "Referrer", "total_referrals", "unique_accounts", "active_days",
+            "burst_count", "avg_days_between", "channels_used", "branches_used",
+            "first_referral", "last_referral", "Influence Score",
+        ]),
+        staff_metrics=pd.DataFrame(columns=[
+            "Staff", "referrals_processed", "unique_referrers",
+            "unique_branches", "avg_referrer_score", "Multiplier Score",
+        ]),
+        settings=sample_referral_settings,
+    )

--- a/tests/referral/analyses/test_branch_density.py
+++ b/tests/referral/analyses/test_branch_density.py
@@ -1,0 +1,59 @@
+"""Tests for R06: Branch Influence Density analysis."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from ics_toolkit.analysis.analyses.base import AnalysisResult
+from ics_toolkit.referral.analyses.branch_density import analyze_branch_density
+
+
+class TestAnalyzeBranchDensity:
+    """Tests for analyze_branch_density."""
+
+    def test_returns_analysis_result(self, referral_context):
+        result = analyze_branch_density(referral_context)
+        assert isinstance(result, AnalysisResult)
+        assert result.name == "Branch Influence Density"
+        assert result.sheet_name == "R06_Branch"
+
+    def test_excludes_unknown_branches(self, referral_context):
+        result = analyze_branch_density(referral_context)
+        if not result.df.empty:
+            assert "UNKNOWN" not in result.df["Branch"].values
+
+    def test_sorted_by_avg_influence_score(self, referral_context):
+        result = analyze_branch_density(referral_context)
+        if len(result.df) > 1:
+            scores = result.df["Avg Influence Score"].values
+            assert all(scores[i] >= scores[i + 1] for i in range(len(scores) - 1))
+
+    def test_output_columns(self, referral_context):
+        result = analyze_branch_density(referral_context)
+        if not result.df.empty:
+            expected = {"Branch", "Total Referrals", "Unique Referrers",
+                        "Avg Influence Score"}
+            assert expected.issubset(set(result.df.columns))
+
+    def test_avg_influence_score_rounded(self, referral_context):
+        result = analyze_branch_density(referral_context)
+        if not result.df.empty:
+            for val in result.df["Avg Influence Score"]:
+                if pd.notna(val):
+                    assert val == round(val, 1)
+
+    def test_has_top_referrer_per_branch(self, referral_context):
+        result = analyze_branch_density(referral_context)
+        if not result.df.empty:
+            assert "Top Referrer" in result.df.columns
+
+    def test_empty_data_returns_empty(self, empty_context):
+        result = analyze_branch_density(empty_context)
+        assert isinstance(result, AnalysisResult)
+        assert result.df.empty
+
+    def test_index_is_reset(self, referral_context):
+        result = analyze_branch_density(referral_context)
+        if not result.df.empty:
+            assert list(result.df.index) == list(range(len(result.df)))

--- a/tests/referral/analyses/test_code_health.py
+++ b/tests/referral/analyses/test_code_health.py
@@ -1,0 +1,53 @@
+"""Tests for R07: Code Health Report analysis."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from ics_toolkit.analysis.analyses.base import AnalysisResult
+from ics_toolkit.referral.analyses.code_health import analyze_code_health
+
+
+class TestAnalyzeCodeHealth:
+    """Tests for analyze_code_health."""
+
+    def test_returns_analysis_result(self, referral_context):
+        result = analyze_code_health(referral_context)
+        assert isinstance(result, AnalysisResult)
+        assert result.name == "Code Health Report"
+        assert result.sheet_name == "R07_Code_Health"
+
+    def test_output_columns(self, referral_context):
+        result = analyze_code_health(referral_context)
+        if not result.df.empty:
+            expected = {"Channel", "Type", "Reliability", "Count", "% of Total"}
+            assert expected.issubset(set(result.df.columns))
+
+    def test_pct_of_total_sums_to_100(self, referral_context):
+        result = analyze_code_health(referral_context)
+        if not result.df.empty:
+            total_pct = result.df["% of Total"].sum()
+            assert abs(total_pct - 100.0) < 0.5
+
+    def test_sorted_by_count_descending(self, referral_context):
+        result = analyze_code_health(referral_context)
+        if len(result.df) > 1:
+            counts = result.df["Count"].values
+            assert all(counts[i] >= counts[i + 1] for i in range(len(counts) - 1))
+
+    def test_known_code_pct_column_present(self, referral_context):
+        result = analyze_code_health(referral_context)
+        if not result.df.empty:
+            assert "Known Code %" in result.df.columns
+
+    def test_known_code_pct_in_valid_range(self, referral_context):
+        result = analyze_code_health(referral_context)
+        if not result.df.empty:
+            for val in result.df["Known Code %"]:
+                assert 0 <= val <= 100
+
+    def test_empty_data_returns_empty(self, empty_context):
+        result = analyze_code_health(empty_context)
+        assert isinstance(result, AnalysisResult)
+        assert result.df.empty

--- a/tests/referral/analyses/test_dormant_referrers.py
+++ b/tests/referral/analyses/test_dormant_referrers.py
@@ -1,0 +1,64 @@
+"""Tests for R03: Dormant High-Value Referrers analysis."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from ics_toolkit.analysis.analyses.base import AnalysisResult
+from ics_toolkit.referral.analyses.dormant_referrers import analyze_dormant_referrers
+
+
+class TestAnalyzeDormantReferrers:
+    """Tests for analyze_dormant_referrers."""
+
+    def test_returns_analysis_result(self, referral_context):
+        result = analyze_dormant_referrers(referral_context)
+        assert isinstance(result, AnalysisResult)
+        assert result.name == "Dormant High-Value Referrers"
+        assert result.sheet_name == "R03_Dormant"
+
+    def test_dormant_means_last_referral_before_cutoff(self, referral_context):
+        result = analyze_dormant_referrers(referral_context)
+        if not result.df.empty:
+            max_date = referral_context.df["Issue Date"].max()
+            dormancy_days = referral_context.settings.dormancy_days
+            cutoff = max_date - pd.Timedelta(days=dormancy_days)
+            assert (result.df["Last Referral"] < cutoff).all()
+
+    def test_days_dormant_is_positive(self, referral_context):
+        result = analyze_dormant_referrers(referral_context)
+        if not result.df.empty:
+            assert (result.df["Days Dormant"] > 0).all()
+
+    def test_sorted_by_historical_score(self, referral_context):
+        result = analyze_dormant_referrers(referral_context)
+        if len(result.df) > 1:
+            scores = result.df["Historical Score"].values
+            assert all(scores[i] >= scores[i + 1] for i in range(len(scores) - 1))
+
+    def test_output_columns(self, referral_context):
+        result = analyze_dormant_referrers(referral_context)
+        if not result.df.empty:
+            expected = {"Referrer", "Historical Score", "Total Referrals",
+                        "Unique Accounts", "Last Referral", "Days Dormant"}
+            assert expected.issubset(set(result.df.columns))
+
+    def test_empty_metrics_returns_empty(self, empty_context):
+        result = analyze_dormant_referrers(empty_context)
+        assert isinstance(result, AnalysisResult)
+        assert result.df.empty
+
+    def test_all_nat_dates_returns_empty(self, referral_context):
+        referral_context.df["Issue Date"] = pd.NaT
+        result = analyze_dormant_referrers(referral_context)
+        assert result.df.empty
+
+    def test_no_dormant_referrers_returns_empty(self, referral_context):
+        """When all referrers are recent, result should be empty."""
+        # Set dormancy to a very large window so nobody qualifies
+        referral_context.settings = referral_context.settings.model_copy(
+            update={"dormancy_days": 9999}
+        )
+        result = analyze_dormant_referrers(referral_context)
+        assert result.df.empty

--- a/tests/referral/analyses/test_emerging_referrers.py
+++ b/tests/referral/analyses/test_emerging_referrers.py
@@ -1,0 +1,57 @@
+"""Tests for R02: Emerging Referrers analysis."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from ics_toolkit.analysis.analyses.base import AnalysisResult
+from ics_toolkit.referral.analyses.emerging_referrers import analyze_emerging_referrers
+
+
+class TestAnalyzeEmergingReferrers:
+    """Tests for analyze_emerging_referrers."""
+
+    def test_returns_analysis_result(self, referral_context):
+        result = analyze_emerging_referrers(referral_context)
+        assert isinstance(result, AnalysisResult)
+        assert result.name == "Emerging Referrers"
+        assert result.sheet_name == "R02_Emerging"
+
+    def test_only_recent_referrers(self, referral_context):
+        result = analyze_emerging_referrers(referral_context)
+        if not result.df.empty:
+            max_date = referral_context.df["Issue Date"].max()
+            lookback = referral_context.settings.emerging_lookback_days
+            cutoff = max_date - pd.Timedelta(days=lookback)
+            assert (result.df["First Referral"] >= cutoff).all()
+
+    def test_meets_burst_minimum(self, referral_context):
+        result = analyze_emerging_referrers(referral_context)
+        if not result.df.empty:
+            min_burst = referral_context.settings.emerging_min_burst_count
+            assert (result.df["Burst Count"] >= min_burst).all()
+
+    def test_sorted_by_influence_score(self, referral_context):
+        result = analyze_emerging_referrers(referral_context)
+        if len(result.df) > 1:
+            scores = result.df["Influence Score"].values
+            assert all(scores[i] >= scores[i + 1] for i in range(len(scores) - 1))
+
+    def test_output_columns(self, referral_context):
+        result = analyze_emerging_referrers(referral_context)
+        if not result.df.empty:
+            assert "Referrer" in result.df.columns
+            assert "Influence Score" in result.df.columns
+            assert "Burst Count" in result.df.columns
+
+    def test_empty_metrics_returns_empty(self, empty_context):
+        result = analyze_emerging_referrers(empty_context)
+        assert isinstance(result, AnalysisResult)
+        assert result.df.empty
+
+    def test_all_nat_dates_returns_empty(self, referral_context):
+        """When all Issue Dates are NaT, should return empty."""
+        referral_context.df["Issue Date"] = pd.NaT
+        result = analyze_emerging_referrers(referral_context)
+        assert result.df.empty

--- a/tests/referral/analyses/test_onetime_vs_repeat.py
+++ b/tests/referral/analyses/test_onetime_vs_repeat.py
@@ -1,0 +1,63 @@
+"""Tests for R04: One-time vs Repeat Referrers analysis."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from ics_toolkit.analysis.analyses.base import AnalysisResult
+from ics_toolkit.referral.analyses.onetime_vs_repeat import analyze_onetime_vs_repeat
+
+
+class TestAnalyzeOnetimeVsRepeat:
+    """Tests for analyze_onetime_vs_repeat."""
+
+    def test_returns_analysis_result(self, referral_context):
+        result = analyze_onetime_vs_repeat(referral_context)
+        assert isinstance(result, AnalysisResult)
+        assert result.name == "One-time vs Repeat Referrers"
+        assert result.sheet_name == "R04_Repeat"
+
+    def test_has_expected_categories(self, referral_context):
+        result = analyze_onetime_vs_repeat(referral_context)
+        categories = set(result.df["Category"].values)
+        assert "Grand Total" in categories
+        # Should have at least one of One-time or Repeat
+        assert categories.intersection({"One-time", "Repeat"})
+
+    def test_grand_total_row_sums_correctly(self, referral_context):
+        result = analyze_onetime_vs_repeat(referral_context)
+        df = result.df
+        grand = df[df["Category"] == "Grand Total"]
+        detail = df[df["Category"] != "Grand Total"]
+        assert grand["Count"].values[0] == detail["Count"].sum()
+
+    def test_grand_total_pct_is_100(self, referral_context):
+        result = analyze_onetime_vs_repeat(referral_context)
+        grand = result.df[result.df["Category"] == "Grand Total"]
+        assert grand["% of Total"].values[0] == 100.0
+
+    def test_output_columns(self, referral_context):
+        result = analyze_onetime_vs_repeat(referral_context)
+        expected = {"Category", "Count", "% of Total", "Avg Unique Accounts",
+                    "Avg Influence Score", "Avg Active Days"}
+        assert expected.issubset(set(result.df.columns))
+
+    def test_float_columns_rounded(self, referral_context):
+        result = analyze_onetime_vs_repeat(referral_context)
+        for col in ["Avg Unique Accounts", "Avg Influence Score", "Avg Active Days"]:
+            if col in result.df.columns:
+                for val in result.df[col]:
+                    if pd.notna(val):
+                        assert val == round(val, 1)
+
+    def test_empty_metrics_returns_empty(self, empty_context):
+        result = analyze_onetime_vs_repeat(empty_context)
+        assert isinstance(result, AnalysisResult)
+        assert result.df.empty
+
+    def test_pct_of_total_sums_to_100(self, referral_context):
+        result = analyze_onetime_vs_repeat(referral_context)
+        detail = result.df[result.df["Category"] != "Grand Total"]
+        total_pct = detail["% of Total"].sum()
+        assert abs(total_pct - 100.0) < 0.1

--- a/tests/referral/analyses/test_overview.py
+++ b/tests/referral/analyses/test_overview.py
@@ -1,0 +1,66 @@
+"""Tests for R08: Overview KPIs analysis."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from ics_toolkit.analysis.analyses.base import AnalysisResult
+from ics_toolkit.referral.analyses.overview import analyze_overview
+
+
+class TestAnalyzeOverview:
+    """Tests for analyze_overview."""
+
+    def test_returns_analysis_result(self, referral_context):
+        result = analyze_overview(referral_context)
+        assert isinstance(result, AnalysisResult)
+        assert result.name == "Overview KPIs"
+        assert result.sheet_name == "R08_Overview"
+
+    def test_output_has_metric_value_columns(self, referral_context):
+        result = analyze_overview(referral_context)
+        assert list(result.df.columns) == ["Metric", "Value"]
+
+    def test_contains_core_kpis(self, referral_context):
+        result = analyze_overview(referral_context)
+        metrics = set(result.df["Metric"].values)
+        assert "Total Referrals" in metrics
+        assert "Unique Referrers" in metrics
+        assert "Unique New Accounts" in metrics
+
+    def test_contains_referrer_behavior_kpis(self, referral_context):
+        result = analyze_overview(referral_context)
+        metrics = set(result.df["Metric"].values)
+        assert "Repeat Referrer %" in metrics
+        assert "Avg Referrals per Referrer" in metrics
+        assert "Top Referrer Score" in metrics
+
+    def test_total_referrals_matches_df_length(self, referral_context):
+        result = analyze_overview(referral_context)
+        total_row = result.df[result.df["Metric"] == "Total Referrals"]
+        assert total_row["Value"].values[0] == len(referral_context.df)
+
+    def test_unique_accounts_matches_nunique(self, referral_context):
+        result = analyze_overview(referral_context)
+        row = result.df[result.df["Metric"] == "Unique New Accounts"]
+        expected = referral_context.df["MRDB Account Hash"].nunique()
+        assert row["Value"].values[0] == expected
+
+    def test_accepts_prior_results(self, referral_context):
+        prior = [
+            AnalysisResult(name="dummy", title="dummy", df=pd.DataFrame()),
+        ]
+        result = analyze_overview(referral_context, prior_results=prior)
+        assert isinstance(result, AnalysisResult)
+
+    def test_empty_metrics_still_produces_kpis(self, empty_context):
+        result = analyze_overview(empty_context)
+        assert isinstance(result, AnalysisResult)
+        metrics = set(result.df["Metric"].values)
+        assert "Total Referrals" in metrics
+
+    def test_empty_metrics_defaults_to_zero(self, empty_context):
+        result = analyze_overview(empty_context)
+        row = result.df[result.df["Metric"] == "Repeat Referrer %"]
+        assert row["Value"].values[0] == 0.0

--- a/tests/referral/analyses/test_registry.py
+++ b/tests/referral/analyses/test_registry.py
@@ -1,0 +1,76 @@
+"""Tests for referral analysis registry and run_all_referral_analyses."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from ics_toolkit.analysis.analyses.base import AnalysisResult
+from ics_toolkit.referral.analyses import (
+    OVERVIEW_ANALYSIS,
+    REFERRAL_ANALYSIS_REGISTRY,
+    run_all_referral_analyses,
+)
+
+
+class TestReferralAnalysisRegistry:
+    """Tests for the referral analysis registry."""
+
+    def test_registry_has_seven_analyses(self):
+        assert len(REFERRAL_ANALYSIS_REGISTRY) == 7
+
+    def test_registry_entries_are_tuples(self):
+        for entry in REFERRAL_ANALYSIS_REGISTRY:
+            assert isinstance(entry, tuple)
+            assert len(entry) == 2
+            name, func = entry
+            assert isinstance(name, str)
+            assert callable(func)
+
+    def test_overview_analysis_is_separate(self):
+        name, func = OVERVIEW_ANALYSIS
+        assert name == "Overview KPIs"
+        assert callable(func)
+
+    def test_registry_names_unique(self):
+        names = [name for name, _ in REFERRAL_ANALYSIS_REGISTRY]
+        assert len(names) == len(set(names))
+
+
+class TestRunAllReferralAnalyses:
+    """Tests for run_all_referral_analyses."""
+
+    def test_returns_list_of_results(self, referral_context):
+        results = run_all_referral_analyses(referral_context)
+        assert isinstance(results, list)
+        assert all(isinstance(r, AnalysisResult) for r in results)
+
+    def test_returns_eight_results(self, referral_context):
+        """7 registry + 1 overview = 8 total."""
+        results = run_all_referral_analyses(referral_context)
+        assert len(results) == 8
+
+    def test_last_result_is_overview(self, referral_context):
+        results = run_all_referral_analyses(referral_context)
+        assert results[-1].name == "Overview KPIs"
+
+    def test_progress_callback_called(self, referral_context):
+        calls = []
+
+        def on_progress(current, total, name):
+            calls.append((current, total, name))
+
+        run_all_referral_analyses(referral_context, on_progress=on_progress)
+        # 7 registry + 1 overview = 8 progress calls
+        assert len(calls) == 8
+
+    def test_no_errors_on_valid_data(self, referral_context):
+        results = run_all_referral_analyses(referral_context)
+        for r in results:
+            assert r.error is None, f"{r.name} had error: {r.error}"
+
+    def test_empty_context_no_crash(self, empty_context):
+        results = run_all_referral_analyses(empty_context)
+        assert len(results) == 8
+        for r in results:
+            assert r.error is None, f"{r.name} had error: {r.error}"

--- a/tests/referral/analyses/test_staff_multipliers.py
+++ b/tests/referral/analyses/test_staff_multipliers.py
@@ -1,0 +1,48 @@
+"""Tests for R05: Staff Multipliers analysis."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from ics_toolkit.analysis.analyses.base import AnalysisResult
+from ics_toolkit.referral.analyses.staff_multipliers import analyze_staff_multipliers
+
+
+class TestAnalyzeStaffMultipliers:
+    """Tests for analyze_staff_multipliers."""
+
+    def test_returns_analysis_result(self, referral_context):
+        result = analyze_staff_multipliers(referral_context)
+        assert isinstance(result, AnalysisResult)
+        assert result.name == "Staff Multipliers"
+        assert result.sheet_name == "R05_Staff"
+
+    def test_sorted_by_multiplier_score_descending(self, referral_context):
+        result = analyze_staff_multipliers(referral_context)
+        if len(result.df) > 1:
+            scores = result.df["Multiplier Score"].values
+            assert all(scores[i] >= scores[i + 1] for i in range(len(scores) - 1))
+
+    def test_output_columns(self, referral_context):
+        result = analyze_staff_multipliers(referral_context)
+        if not result.df.empty:
+            assert "Staff" in result.df.columns
+            assert "Multiplier Score" in result.df.columns
+
+    def test_avg_referrer_score_rounded(self, referral_context):
+        result = analyze_staff_multipliers(referral_context)
+        if not result.df.empty and "Avg Referrer Score" in result.df.columns:
+            for val in result.df["Avg Referrer Score"]:
+                if pd.notna(val):
+                    assert val == round(val, 1)
+
+    def test_empty_metrics_returns_empty(self, empty_context):
+        result = analyze_staff_multipliers(empty_context)
+        assert isinstance(result, AnalysisResult)
+        assert result.df.empty
+
+    def test_index_is_reset(self, referral_context):
+        result = analyze_staff_multipliers(referral_context)
+        if not result.df.empty:
+            assert list(result.df.index) == list(range(len(result.df)))

--- a/tests/referral/analyses/test_top_referrers.py
+++ b/tests/referral/analyses/test_top_referrers.py
@@ -1,0 +1,51 @@
+"""Tests for R01: Top Referrers analysis."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from ics_toolkit.analysis.analyses.base import AnalysisResult
+from ics_toolkit.referral.analyses.top_referrers import analyze_top_referrers
+
+
+class TestAnalyzeTopReferrers:
+    """Tests for analyze_top_referrers."""
+
+    def test_returns_analysis_result(self, referral_context):
+        result = analyze_top_referrers(referral_context)
+        assert isinstance(result, AnalysisResult)
+        assert result.name == "Top Referrers"
+        assert result.sheet_name == "R01_Top_Referrers"
+
+    def test_excludes_single_referral_referrers(self, referral_context):
+        result = analyze_top_referrers(referral_context)
+        if not result.df.empty:
+            assert (result.df["Total Referrals"] > 1).all()
+
+    def test_sorted_by_influence_score_descending(self, referral_context):
+        result = analyze_top_referrers(referral_context)
+        if len(result.df) > 1:
+            scores = result.df["Influence Score"].values
+            assert all(scores[i] >= scores[i + 1] for i in range(len(scores) - 1))
+
+    def test_respects_top_n_limit(self, referral_context):
+        result = analyze_top_referrers(referral_context)
+        assert len(result.df) <= referral_context.settings.top_n_referrers
+
+    def test_output_columns(self, referral_context):
+        result = analyze_top_referrers(referral_context)
+        if not result.df.empty:
+            assert "Referrer" in result.df.columns
+            assert "Influence Score" in result.df.columns
+            assert "Total Referrals" in result.df.columns
+
+    def test_empty_metrics_returns_empty(self, empty_context):
+        result = analyze_top_referrers(empty_context)
+        assert isinstance(result, AnalysisResult)
+        assert result.df.empty
+
+    def test_index_is_reset(self, referral_context):
+        result = analyze_top_referrers(referral_context)
+        if not result.df.empty:
+            assert list(result.df.index) == list(range(len(result.df)))

--- a/tests/referral/charts/test_referral_charts.py
+++ b/tests/referral/charts/test_referral_charts.py
@@ -1,0 +1,197 @@
+"""Tests for referral chart builders and registry."""
+
+from __future__ import annotations
+
+import pandas as pd
+import plotly.graph_objects as go
+import pytest
+
+from ics_toolkit.analysis.analyses.base import AnalysisResult
+from ics_toolkit.referral.charts import (
+    REFERRAL_CHART_REGISTRY,
+    create_referral_charts,
+)
+from ics_toolkit.referral.charts.branch_density import chart_branch_density
+from ics_toolkit.referral.charts.code_health import chart_code_health
+from ics_toolkit.referral.charts.emerging_referrers import chart_emerging_referrers
+from ics_toolkit.referral.charts.staff_multipliers import chart_staff_multipliers
+from ics_toolkit.referral.charts.top_referrers import chart_top_referrers
+from ics_toolkit.settings import ChartConfig
+
+
+@pytest.fixture
+def chart_config():
+    return ChartConfig()
+
+
+@pytest.fixture
+def top_referrers_df():
+    return pd.DataFrame({
+        "Referrer": ["ALICE", "BOB", "CHARLIE"],
+        "Influence Score": [85.0, 72.0, 60.0],
+        "Total Referrals": [10, 7, 5],
+        "Unique Accounts": [8, 6, 4],
+    })
+
+
+@pytest.fixture
+def emerging_referrers_df():
+    return pd.DataFrame({
+        "Referrer": ["NEW_A", "NEW_B"],
+        "Influence Score": [70.0, 55.0],
+        "Burst Count": [3, 2],
+        "First Referral": pd.to_datetime(["2025-12-01", "2025-11-15"]),
+    })
+
+
+@pytest.fixture
+def staff_df():
+    return pd.DataFrame({
+        "Staff": ["SARAH", "MIKE"],
+        "Multiplier Score": [80.0, 60.0],
+        "Referrals Processed": [25, 18],
+        "Unique Referrers": [10, 8],
+    })
+
+
+@pytest.fixture
+def branch_df():
+    return pd.DataFrame({
+        "Branch": ["001", "002", "003"],
+        "Avg Influence Score": [75.0, 60.0, 45.0],
+        "Total Referrals": [20, 15, 10],
+    })
+
+
+@pytest.fixture
+def code_health_df():
+    return pd.DataFrame({
+        "Channel": ["BRANCH_STANDARD", "BRANCH_STANDARD", "MANUAL"],
+        "Type": ["Standard", "Standard", "Manual"],
+        "Reliability": ["High", "Medium", "Low"],
+        "Count": [30, 10, 5],
+        "% of Total": [66.67, 22.22, 11.11],
+    })
+
+
+class TestChartRegistry:
+    def test_has_five_entries(self):
+        assert len(REFERRAL_CHART_REGISTRY) == 5
+
+    def test_all_entries_callable(self):
+        for name, func in REFERRAL_CHART_REGISTRY.items():
+            assert callable(func), f"{name} is not callable"
+
+    def test_expected_names(self):
+        expected = {
+            "Top Referrers", "Emerging Referrers", "Staff Multipliers",
+            "Branch Influence Density", "Code Health Report",
+        }
+        assert set(REFERRAL_CHART_REGISTRY.keys()) == expected
+
+
+class TestChartTopReferrers:
+    def test_returns_figure(self, top_referrers_df, chart_config):
+        fig = chart_top_referrers(top_referrers_df, chart_config)
+        assert isinstance(fig, go.Figure)
+
+    def test_has_bar_trace(self, top_referrers_df, chart_config):
+        fig = chart_top_referrers(top_referrers_df, chart_config)
+        assert any(isinstance(t, go.Bar) for t in fig.data)
+
+    def test_horizontal_orientation(self, top_referrers_df, chart_config):
+        fig = chart_top_referrers(top_referrers_df, chart_config)
+        bar = [t for t in fig.data if isinstance(t, go.Bar)][0]
+        assert bar.orientation == "h"
+
+
+class TestChartEmergingReferrers:
+    def test_returns_figure(self, emerging_referrers_df, chart_config):
+        fig = chart_emerging_referrers(emerging_referrers_df, chart_config)
+        assert isinstance(fig, go.Figure)
+
+    def test_has_scatter_trace(self, emerging_referrers_df, chart_config):
+        fig = chart_emerging_referrers(emerging_referrers_df, chart_config)
+        assert any(isinstance(t, go.Scatter) for t in fig.data)
+
+    def test_marker_mode(self, emerging_referrers_df, chart_config):
+        fig = chart_emerging_referrers(emerging_referrers_df, chart_config)
+        scatter = [t for t in fig.data if isinstance(t, go.Scatter)][0]
+        assert scatter.mode == "markers"
+
+
+class TestChartStaffMultipliers:
+    def test_returns_figure(self, staff_df, chart_config):
+        fig = chart_staff_multipliers(staff_df, chart_config)
+        assert isinstance(fig, go.Figure)
+
+    def test_has_bar_traces(self, staff_df, chart_config):
+        fig = chart_staff_multipliers(staff_df, chart_config)
+        bars = [t for t in fig.data if isinstance(t, go.Bar)]
+        assert len(bars) >= 1
+
+    def test_grouped_barmode(self, staff_df, chart_config):
+        fig = chart_staff_multipliers(staff_df, chart_config)
+        assert fig.layout.barmode == "group"
+
+
+class TestChartBranchDensity:
+    def test_returns_figure(self, branch_df, chart_config):
+        fig = chart_branch_density(branch_df, chart_config)
+        assert isinstance(fig, go.Figure)
+
+    def test_has_bar_trace(self, branch_df, chart_config):
+        fig = chart_branch_density(branch_df, chart_config)
+        assert any(isinstance(t, go.Bar) for t in fig.data)
+
+    def test_vertical_orientation(self, branch_df, chart_config):
+        fig = chart_branch_density(branch_df, chart_config)
+        bar = [t for t in fig.data if isinstance(t, go.Bar)][0]
+        # Default orientation is vertical (None or "v")
+        assert bar.orientation in (None, "v")
+
+
+class TestChartCodeHealth:
+    def test_returns_figure(self, code_health_df, chart_config):
+        fig = chart_code_health(code_health_df, chart_config)
+        assert isinstance(fig, go.Figure)
+
+    def test_stacked_barmode(self, code_health_df, chart_config):
+        fig = chart_code_health(code_health_df, chart_config)
+        assert fig.layout.barmode == "stack"
+
+    def test_one_trace_per_reliability(self, code_health_df, chart_config):
+        fig = chart_code_health(code_health_df, chart_config)
+        n_reliabilities = code_health_df["Reliability"].nunique()
+        assert len(fig.data) == n_reliabilities
+
+
+class TestCreateReferralCharts:
+    def test_creates_charts_for_matching_analyses(self, top_referrers_df, chart_config):
+        analyses = [
+            AnalysisResult(name="Top Referrers", title="Top Referrers", df=top_referrers_df),
+        ]
+        charts = create_referral_charts(analyses, chart_config)
+        assert "Top Referrers" in charts
+        assert isinstance(charts["Top Referrers"], go.Figure)
+
+    def test_skips_empty_analyses(self, chart_config):
+        analyses = [
+            AnalysisResult(name="Top Referrers", title="Top Referrers", df=pd.DataFrame()),
+        ]
+        charts = create_referral_charts(analyses, chart_config)
+        assert "Top Referrers" not in charts
+
+    def test_skips_errored_analyses(self, top_referrers_df, chart_config):
+        analyses = [
+            AnalysisResult(name="Top Referrers", title="Top Referrers", df=top_referrers_df, error="oops"),
+        ]
+        charts = create_referral_charts(analyses, chart_config)
+        assert "Top Referrers" not in charts
+
+    def test_skips_unregistered_analyses(self, chart_config):
+        analyses = [
+            AnalysisResult(name="Unknown Analysis", title="Unknown", df=pd.DataFrame({"a": [1]})),
+        ]
+        charts = create_referral_charts(analyses, chart_config)
+        assert len(charts) == 0

--- a/tests/referral/conftest.py
+++ b/tests/referral/conftest.py
@@ -1,0 +1,106 @@
+"""Shared fixtures for referral pipeline tests."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from ics_toolkit.referral.column_map import REQUIRED_COLUMNS
+from ics_toolkit.settings import ReferralSettings
+
+REFERENCE_DATE = datetime(2026, 1, 15)
+
+REFERRERS = [
+    "JOHN SMITH",
+    "JANE DOE",
+    "BOB WILSON",
+    "ALICE BROWN",
+    "TOM JONES",
+    "MARY CLARK",
+    "DAVID HALL",
+    "SARAH KING",
+]
+STAFF = ["SARAH MANAGER", "MIKE HANDLER", "LISA PROCESSOR"]
+BRANCHES = ["001", "002", "003"]
+CODES = [
+    "150A001",
+    "120A002",
+    "PC100",
+    None,
+    "EMAIL_Q1",
+    "080A003",
+    None,
+    "UNKNOWN_XYZ",
+]
+
+
+@pytest.fixture(scope="session")
+def rng():
+    """Deterministic random number generator."""
+    return np.random.default_rng(42)
+
+
+@pytest.fixture
+def sample_referral_df(rng):
+    """50-row deterministic referral dataset with known patterns.
+
+    Guarantees:
+    - At least some referrers have multiple referrals (JOHN SMITH, JANE DOE)
+    - Mix of null and non-null referral codes
+    - All branches represented
+    - Sequential dates covering ~1 year
+    """
+    n = 50
+    # Bias toward repeat referrers for testable patterns
+    referrer_weights = [0.25, 0.20, 0.15, 0.10, 0.10, 0.08, 0.07, 0.05]
+    referrers = rng.choice(REFERRERS, n, p=referrer_weights)
+
+    return pd.DataFrame(
+        {
+            "Referrer Name": referrers,
+            "Issue Date": pd.date_range("2025-01-01", periods=n, freq="7D"),
+            "Referral Code": rng.choice(CODES, n),
+            "Purchase Manager": rng.choice(STAFF, n),
+            "Branch": rng.choice(BRANCHES, n),
+            "Account Holder": [f"NEW_ACCOUNT_{i:03d}" for i in range(n)],
+            "MRDB Account Hash": [f"HASH_{i:04d}" for i in range(n)],
+            "Cert ID": [f"CERT_{i:04d}" for i in range(n)],
+        }
+    )
+
+
+@pytest.fixture
+def sample_referral_settings(tmp_path, sample_referral_df):
+    """Write sample data to tmp xlsx and create ReferralSettings."""
+    data_path = tmp_path / "test_referral.xlsx"
+    sample_referral_df.to_excel(data_path, index=False, engine="openpyxl")
+    return ReferralSettings(
+        data_file=data_path,
+        output_dir=tmp_path / "output",
+    )
+
+
+@pytest.fixture
+def empty_referral_df():
+    """Empty DataFrame with correct columns."""
+    return pd.DataFrame(columns=REQUIRED_COLUMNS)
+
+
+@pytest.fixture
+def single_row_referral_df():
+    """Single-row DataFrame for edge-case testing."""
+    return pd.DataFrame(
+        {
+            "Referrer Name": ["JOHN SMITH"],
+            "Issue Date": [pd.Timestamp("2025-06-15")],
+            "Referral Code": ["150A001"],
+            "Purchase Manager": ["SARAH MANAGER"],
+            "Branch": ["001"],
+            "Account Holder": ["NEW_PERSON"],
+            "MRDB Account Hash": ["HASH_SINGLE"],
+            "Cert ID": ["CERT_SINGLE"],
+        }
+    )

--- a/tests/referral/test_code_decoder.py
+++ b/tests/referral/test_code_decoder.py
@@ -1,0 +1,95 @@
+"""Tests for referral code decoder."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from ics_toolkit.referral.code_decoder import _classify_channel, decode_referral_codes
+from ics_toolkit.settings import ReferralSettings
+
+
+@pytest.fixture
+def settings():
+    return ReferralSettings()
+
+
+class TestClassifyChannel:
+    def test_null_is_manual(self, settings):
+        prefixes = sorted(settings.code_prefix_map.keys(), key=len, reverse=True)
+        assert _classify_channel(None, prefixes, settings.code_prefix_map) == "MANUAL"
+
+    def test_empty_string_is_manual(self, settings):
+        prefixes = sorted(settings.code_prefix_map.keys(), key=len, reverse=True)
+        assert _classify_channel("", prefixes, settings.code_prefix_map) == "MANUAL"
+
+    def test_none_string_is_manual(self, settings):
+        prefixes = sorted(settings.code_prefix_map.keys(), key=len, reverse=True)
+        assert _classify_channel("None", prefixes, settings.code_prefix_map) == "MANUAL"
+
+    def test_branch_prefix_150a(self, settings):
+        prefixes = sorted(settings.code_prefix_map.keys(), key=len, reverse=True)
+        assert _classify_channel("150A001", prefixes, settings.code_prefix_map) == "BRANCH_STANDARD"
+
+    def test_branch_prefix_120a(self, settings):
+        prefixes = sorted(settings.code_prefix_map.keys(), key=len, reverse=True)
+        assert _classify_channel("120A002", prefixes, settings.code_prefix_map) == "BRANCH_STANDARD"
+
+    def test_digital_prefix_pc(self, settings):
+        prefixes = sorted(settings.code_prefix_map.keys(), key=len, reverse=True)
+        assert _classify_channel("PC100", prefixes, settings.code_prefix_map) == "DIGITAL_PROCESS"
+
+    def test_email_keyword(self, settings):
+        prefixes = sorted(settings.code_prefix_map.keys(), key=len, reverse=True)
+        assert _classify_channel("EMAIL_Q1", prefixes, settings.code_prefix_map) == "EMAIL"
+
+    def test_unknown_code_is_other(self, settings):
+        prefixes = sorted(settings.code_prefix_map.keys(), key=len, reverse=True)
+        assert _classify_channel("UNKNOWN_XYZ", prefixes, settings.code_prefix_map) == "OTHER"
+
+    def test_case_insensitive(self, settings):
+        prefixes = sorted(settings.code_prefix_map.keys(), key=len, reverse=True)
+        assert _classify_channel("150a001", prefixes, settings.code_prefix_map) == "BRANCH_STANDARD"
+        assert _classify_channel("pc200", prefixes, settings.code_prefix_map) == "DIGITAL_PROCESS"
+
+    def test_whitespace_stripped(self, settings):
+        prefixes = sorted(settings.code_prefix_map.keys(), key=len, reverse=True)
+        assert _classify_channel("  150A001  ", prefixes, settings.code_prefix_map) == "BRANCH_STANDARD"
+
+
+class TestDecodeReferralCodes:
+    def test_adds_three_columns(self, sample_referral_df, settings):
+        result = decode_referral_codes(sample_referral_df, settings)
+        assert "Referral Channel" in result.columns
+        assert "Referral Type" in result.columns
+        assert "Referral Reliability" in result.columns
+
+    def test_no_nulls_in_channel(self, sample_referral_df, settings):
+        result = decode_referral_codes(sample_referral_df, settings)
+        assert result["Referral Channel"].notna().all()
+
+    def test_type_values(self, sample_referral_df, settings):
+        result = decode_referral_codes(sample_referral_df, settings)
+        valid_types = {"Standard", "Manual", "Exception"}
+        assert set(result["Referral Type"].unique()) <= valid_types
+
+    def test_reliability_values(self, sample_referral_df, settings):
+        result = decode_referral_codes(sample_referral_df, settings)
+        valid_rel = {"High", "Medium", "Low"}
+        assert set(result["Referral Reliability"].unique()) <= valid_rel
+
+    def test_custom_prefix_map(self, sample_referral_df):
+        custom = ReferralSettings(code_prefix_map={"CUSTOM": "CUSTOM_CHANNEL"})
+        df = sample_referral_df.copy()
+        df.loc[0, "Referral Code"] = "CUSTOM_001"
+        result = decode_referral_codes(df, custom)
+        assert result.loc[0, "Referral Channel"] == "CUSTOM_CHANNEL"
+
+    def test_all_null_codes(self, settings):
+        df = pd.DataFrame({
+            "Referral Code": [None, None, None],
+        })
+        result = decode_referral_codes(df, settings)
+        assert (result["Referral Channel"] == "MANUAL").all()
+        assert (result["Referral Type"] == "Manual").all()
+        assert (result["Referral Reliability"] == "Medium").all()

--- a/tests/referral/test_column_map.py
+++ b/tests/referral/test_column_map.py
@@ -1,0 +1,40 @@
+"""Tests for referral column map."""
+
+from ics_toolkit.referral.column_map import COLUMN_ALIASES, REQUIRED_COLUMNS
+
+
+class TestRequiredColumns:
+    """Tests for the required columns list."""
+
+    def test_has_eight_columns(self):
+        assert len(REQUIRED_COLUMNS) == 8
+
+    def test_contains_expected_columns(self):
+        expected = {
+            "Referrer Name",
+            "Issue Date",
+            "Referral Code",
+            "Purchase Manager",
+            "Branch",
+            "Account Holder",
+            "MRDB Account Hash",
+            "Cert ID",
+        }
+        assert set(REQUIRED_COLUMNS) == expected
+
+
+class TestColumnAliases:
+    """Tests for column alias mappings."""
+
+    def test_all_aliases_map_to_required_columns(self):
+        for alias, canonical in COLUMN_ALIASES.items():
+            assert canonical in REQUIRED_COLUMNS, f"Alias '{alias}' maps to unknown column '{canonical}'"
+
+    def test_all_required_columns_have_at_least_one_alias(self):
+        aliased = set(COLUMN_ALIASES.values())
+        for col in REQUIRED_COLUMNS:
+            assert col in aliased, f"Required column '{col}' has no alias"
+
+    def test_aliases_are_lowercase(self):
+        for alias in COLUMN_ALIASES:
+            assert alias == alias.lower(), f"Alias '{alias}' is not lowercase"

--- a/tests/referral/test_data_loader.py
+++ b/tests/referral/test_data_loader.py
@@ -1,0 +1,178 @@
+"""Tests for referral data loader."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from ics_toolkit.exceptions import DataError
+from ics_toolkit.referral.column_map import REQUIRED_COLUMNS
+from ics_toolkit.referral.data_loader import (
+    _parse_dates,
+    _read_file,
+    _resolve_aliases,
+    _validate_columns,
+    _validate_primary_key,
+    load_referral_data,
+)
+from ics_toolkit.settings import ReferralSettings
+
+
+class TestLoadReferralData:
+    """Integration tests for the full load pipeline."""
+
+    def test_loads_xlsx(self, sample_referral_settings):
+        df = load_referral_data(sample_referral_settings)
+        assert len(df) == 50
+        for col in REQUIRED_COLUMNS:
+            assert col in df.columns
+
+    def test_issue_date_is_datetime(self, sample_referral_settings):
+        df = load_referral_data(sample_referral_settings)
+        assert pd.api.types.is_datetime64_any_dtype(df["Issue Date"])
+
+    def test_raises_on_no_file(self):
+        settings = ReferralSettings()
+        with pytest.raises(DataError, match="No referral data file"):
+            load_referral_data(settings)
+
+    def test_loads_csv(self, tmp_path, sample_referral_df):
+        csv_path = tmp_path / "test.csv"
+        sample_referral_df.to_csv(csv_path, index=False)
+        settings = ReferralSettings(data_file=csv_path, output_dir=tmp_path / "out")
+        df = load_referral_data(settings)
+        assert len(df) == 50
+
+
+class TestReadFile:
+    """Tests for file format detection."""
+
+    def test_reads_xlsx(self, tmp_path, sample_referral_df):
+        path = tmp_path / "test.xlsx"
+        sample_referral_df.to_excel(path, index=False, engine="openpyxl")
+        df = _read_file(path)
+        assert len(df) == 50
+
+    def test_reads_csv(self, tmp_path, sample_referral_df):
+        path = tmp_path / "test.csv"
+        sample_referral_df.to_csv(path, index=False)
+        df = _read_file(path)
+        assert len(df) == 50
+
+    def test_rejects_unsupported_format(self, tmp_path):
+        path = tmp_path / "test.json"
+        path.write_text("{}")
+        with pytest.raises(DataError, match="Unsupported file type"):
+            _read_file(path)
+
+    def test_header_row_offset(self, tmp_path, sample_referral_df):
+        path = tmp_path / "test_offset.xlsx"
+        # Write with a blank row above by prepending a row
+        df_with_header = pd.concat(
+            [
+                pd.DataFrame([[""] * len(sample_referral_df.columns)], columns=sample_referral_df.columns),
+                sample_referral_df,
+            ],
+            ignore_index=True,
+        )
+        df_with_header.to_excel(path, index=False, engine="openpyxl")
+        df = _read_file(path, header_row=1)
+        assert len(df) == 50
+
+
+class TestResolveAliases:
+    """Tests for column alias resolution."""
+
+    def test_resolves_snake_case_aliases(self):
+        df = pd.DataFrame(
+            {
+                "referrer_name": ["A"],
+                "issue_date": ["2025-01-01"],
+                "referral_code": ["X"],
+                "purchase_manager": ["S"],
+                "branch": ["1"],
+                "account_holder": ["B"],
+                "mrdb_account_hash": ["H"],
+                "cert_id": ["C"],
+            }
+        )
+        result = _resolve_aliases(df)
+        for col in REQUIRED_COLUMNS:
+            assert col in result.columns, f"Missing: {col}"
+
+    def test_preserves_canonical_columns(self, sample_referral_df):
+        result = _resolve_aliases(sample_referral_df)
+        for col in REQUIRED_COLUMNS:
+            assert col in result.columns
+
+    def test_mixed_aliases_and_canonical(self):
+        df = pd.DataFrame(
+            {
+                "Referrer Name": ["A"],
+                "issue_date": ["2025-01-01"],
+                "Referral Code": ["X"],
+                "staff": ["S"],
+                "Branch": ["1"],
+                "Account Holder": ["B"],
+                "mrdb": ["H"],
+                "Cert ID": ["C"],
+            }
+        )
+        result = _resolve_aliases(df)
+        for col in REQUIRED_COLUMNS:
+            assert col in result.columns, f"Missing: {col}"
+
+
+class TestValidateColumns:
+    """Tests for required column validation."""
+
+    def test_passes_with_all_columns(self, tmp_path, sample_referral_df):
+        _validate_columns(sample_referral_df, tmp_path / "test.xlsx")
+
+    def test_fails_on_missing_column(self, tmp_path):
+        df = pd.DataFrame({"Referrer Name": ["A"], "Issue Date": ["2025-01-01"]})
+        with pytest.raises(DataError, match="Missing required columns"):
+            _validate_columns(df, tmp_path / "test.xlsx")
+
+
+class TestValidatePrimaryKey:
+    """Tests for MRDB Account Hash validation."""
+
+    def test_passes_with_valid_pks(self, sample_referral_df):
+        result = _validate_primary_key(sample_referral_df)
+        assert len(result) == 50
+
+    def test_drops_null_pks(self, sample_referral_df):
+        df = sample_referral_df.copy()
+        df.loc[0, "MRDB Account Hash"] = None
+        df.loc[1, "MRDB Account Hash"] = None
+        result = _validate_primary_key(df)
+        assert len(result) == 48
+
+    def test_raises_on_all_null_pks(self):
+        df = pd.DataFrame(
+            {
+                "MRDB Account Hash": [None, None, None],
+                "Other": [1, 2, 3],
+            }
+        )
+        with pytest.raises(DataError, match="All rows have null MRDB Account Hash"):
+            _validate_primary_key(df)
+
+
+class TestParseDates:
+    """Tests for Issue Date parsing."""
+
+    def test_parses_valid_dates(self, sample_referral_df):
+        result = _parse_dates(sample_referral_df)
+        assert pd.api.types.is_datetime64_any_dtype(result["Issue Date"])
+
+    def test_coerces_bad_dates_to_nat(self):
+        df = pd.DataFrame({"Issue Date": ["2025-01-01", "not-a-date", "2025-03-15"]})
+        result = _parse_dates(df)
+        assert result["Issue Date"].isna().sum() == 1
+
+    def test_handles_all_nat(self):
+        df = pd.DataFrame({"Issue Date": ["bad1", "bad2"]})
+        result = _parse_dates(df)
+        assert result["Issue Date"].isna().sum() == 2

--- a/tests/referral/test_network.py
+++ b/tests/referral/test_network.py
@@ -1,0 +1,65 @@
+"""Tests for network inference."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from ics_toolkit.referral.network import infer_networks
+from ics_toolkit.referral.normalizer import normalize_entities
+from ics_toolkit.settings import ReferralSettings
+
+
+@pytest.fixture
+def settings():
+    return ReferralSettings()
+
+
+@pytest.fixture
+def normalized_df(sample_referral_df, settings):
+    return normalize_entities(sample_referral_df, settings)
+
+
+class TestInferNetworks:
+    def test_adds_network_columns(self, normalized_df):
+        result = infer_networks(normalized_df)
+        assert "Network ID" in result.columns
+        assert "Network Size" in result.columns
+
+    def test_network_id_format(self, normalized_df):
+        result = infer_networks(normalized_df)
+        for nid in result["Network ID"].dropna():
+            assert ":" in nid, f"Network ID should contain ':' separator, got: {nid}"
+
+    def test_network_size_positive(self, normalized_df):
+        result = infer_networks(normalized_df)
+        assert (result["Network Size"] > 0).all()
+
+    def test_same_referrer_same_surname_grouped(self):
+        df = pd.DataFrame({
+            "Referrer": ["JOHN SMITH", "JOHN SMITH"],
+            "Account Surname": ["JONES", "JONES"],
+            "MRDB Account Hash": ["H1", "H2"],
+        })
+        result = infer_networks(df)
+        assert result["Network ID"].nunique() == 1
+        assert result["Network Size"].iloc[0] == 2
+
+    def test_different_surnames_separate_networks(self):
+        df = pd.DataFrame({
+            "Referrer": ["JOHN SMITH", "JOHN SMITH"],
+            "Account Surname": ["JONES", "BROWN"],
+            "MRDB Account Hash": ["H1", "H2"],
+        })
+        result = infer_networks(df)
+        assert result["Network ID"].nunique() == 2
+
+    def test_preserves_row_count(self, normalized_df):
+        result = infer_networks(normalized_df)
+        assert len(result) == len(normalized_df)
+
+    def test_empty_dataframe(self):
+        df = pd.DataFrame(columns=["Referrer", "Account Surname", "MRDB Account Hash"])
+        result = infer_networks(df)
+        assert len(result) == 0
+        assert "Network ID" in result.columns

--- a/tests/referral/test_normalizer.py
+++ b/tests/referral/test_normalizer.py
@@ -1,0 +1,149 @@
+"""Tests for entity normalizer."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from ics_toolkit.referral.normalizer import (
+    SUFFIXES,
+    _extract_surname,
+    _normalize_name,
+    normalize_entities,
+)
+from ics_toolkit.settings import ReferralSettings
+
+
+@pytest.fixture
+def settings():
+    return ReferralSettings()
+
+
+class TestNormalizeEntities:
+    def test_adds_canonical_columns(self, sample_referral_df, settings):
+        result = normalize_entities(sample_referral_df, settings)
+        for col in ["Referrer", "New Account", "Staff", "Branch Code", "Branch Label",
+                     "Referrer Surname", "Account Surname"]:
+            assert col in result.columns, f"Missing: {col}"
+
+    def test_preserves_original_columns(self, sample_referral_df, settings):
+        result = normalize_entities(sample_referral_df, settings)
+        assert "Referrer Name" in result.columns
+        assert "Account Holder" in result.columns
+
+    def test_referrer_is_uppercase(self, sample_referral_df, settings):
+        result = normalize_entities(sample_referral_df, settings)
+        for val in result["Referrer"]:
+            assert val == val.upper()
+
+    def test_null_referrer_becomes_unknown(self, settings):
+        df = pd.DataFrame({
+            "Referrer Name": [None, "  ", "JOHN"],
+            "Issue Date": ["2025-01-01"] * 3,
+            "Referral Code": ["X"] * 3,
+            "Purchase Manager": ["S"] * 3,
+            "Branch": ["1"] * 3,
+            "Account Holder": ["A"] * 3,
+            "MRDB Account Hash": ["H1", "H2", "H3"],
+            "Cert ID": ["C1", "C2", "C3"],
+        })
+        result = normalize_entities(df, settings)
+        assert result["Referrer"].iloc[0] == "UNKNOWN"
+        assert result["Referrer"].iloc[2] == "JOHN"
+
+    def test_null_staff_becomes_unassigned(self, settings):
+        df = pd.DataFrame({
+            "Referrer Name": ["JOHN"],
+            "Issue Date": ["2025-01-01"],
+            "Referral Code": ["X"],
+            "Purchase Manager": [None],
+            "Branch": ["1"],
+            "Account Holder": ["A"],
+            "MRDB Account Hash": ["H1"],
+            "Cert ID": ["C1"],
+        })
+        result = normalize_entities(df, settings)
+        assert result["Staff"].iloc[0] == "UNASSIGNED"
+
+    def test_branch_mapping(self):
+        settings = ReferralSettings(branch_mapping={"001": "Main Branch", "002": "West"})
+        df = pd.DataFrame({
+            "Referrer Name": ["A", "B"],
+            "Issue Date": ["2025-01-01"] * 2,
+            "Referral Code": ["X"] * 2,
+            "Purchase Manager": ["S"] * 2,
+            "Branch": ["001", "003"],
+            "Account Holder": ["N1", "N2"],
+            "MRDB Account Hash": ["H1", "H2"],
+            "Cert ID": ["C1", "C2"],
+        })
+        result = normalize_entities(df, settings)
+        assert result["Branch Label"].iloc[0] == "Main Branch"
+        assert result["Branch Label"].iloc[1] == "003"
+
+    def test_name_aliases(self):
+        settings = ReferralSettings(name_aliases={"J SMITH": "JOHN SMITH"})
+        df = pd.DataFrame({
+            "Referrer Name": ["j smith", "JOHN SMITH"],
+            "Issue Date": ["2025-01-01"] * 2,
+            "Referral Code": ["X"] * 2,
+            "Purchase Manager": ["S"] * 2,
+            "Branch": ["1"] * 2,
+            "Account Holder": ["A", "B"],
+            "MRDB Account Hash": ["H1", "H2"],
+            "Cert ID": ["C1", "C2"],
+        })
+        result = normalize_entities(df, settings)
+        assert result["Referrer"].iloc[0] == "JOHN SMITH"
+        assert result["Referrer"].iloc[1] == "JOHN SMITH"
+
+
+class TestNormalizeName:
+    def test_strips_and_uppercases(self):
+        series = pd.Series(["  john smith  ", "Jane Doe"])
+        result = _normalize_name(series, {}, "UNKNOWN")
+        assert result.iloc[0] == "JOHN SMITH"
+        assert result.iloc[1] == "JANE DOE"
+
+    def test_collapses_whitespace(self):
+        series = pd.Series(["JOHN    SMITH"])
+        result = _normalize_name(series, {}, "UNKNOWN")
+        assert result.iloc[0] == "JOHN SMITH"
+
+    def test_null_to_sentinel(self):
+        series = pd.Series([None, ""])
+        result = _normalize_name(series, {}, "UNKNOWN")
+        assert result.iloc[0] == "UNKNOWN"
+        assert result.iloc[1] == "UNKNOWN"
+
+
+class TestExtractSurname:
+    def test_standard_two_word_name(self):
+        result = _extract_surname(pd.Series(["JOHN SMITH"]))
+        assert result.iloc[0] == "SMITH"
+
+    def test_single_word_name(self):
+        result = _extract_surname(pd.Series(["MADONNA"]))
+        assert result.iloc[0] == "MADONNA"
+
+    def test_skips_jr_suffix(self):
+        result = _extract_surname(pd.Series(["JOHN SMITH JR"]))
+        assert result.iloc[0] == "SMITH"
+
+    def test_skips_sr_suffix(self):
+        result = _extract_surname(pd.Series(["MARY JONES SR"]))
+        assert result.iloc[0] == "JONES"
+
+    def test_skips_roman_numeral_suffix(self):
+        result = _extract_surname(pd.Series(["WILLIAM GATES III"]))
+        assert result.iloc[0] == "GATES"
+
+    def test_two_word_with_suffix_only_has_two_parts(self):
+        # "SMITH JR" -> only 2 parts, last is suffix but no preceding surname
+        result = _extract_surname(pd.Series(["SMITH JR"]))
+        assert result.iloc[0] == "JR"  # Can't skip suffix when only 2 parts
+
+    def test_suffixes_constant(self):
+        assert "JR" in SUFFIXES
+        assert "SR" in SUFFIXES
+        assert "III" in SUFFIXES

--- a/tests/referral/test_pipeline.py
+++ b/tests/referral/test_pipeline.py
@@ -1,0 +1,113 @@
+"""Tests for referral pipeline orchestrator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from ics_toolkit.analysis.analyses.base import AnalysisResult
+from ics_toolkit.referral.pipeline import (
+    ReferralPipelineResult,
+    export_outputs,
+    run_pipeline,
+)
+from ics_toolkit.settings import ReferralSettings
+
+
+class TestRunPipeline:
+    """Tests for run_pipeline."""
+
+    def test_returns_pipeline_result(self, sample_referral_settings):
+        result = run_pipeline(sample_referral_settings, skip_charts=True)
+        assert isinstance(result, ReferralPipelineResult)
+
+    def test_result_has_enriched_df(self, sample_referral_settings):
+        result = run_pipeline(sample_referral_settings, skip_charts=True)
+        assert not result.df.empty
+        assert "Referrer" in result.df.columns
+        assert "Influence Score" not in result.df.columns  # scores are in metrics
+
+    def test_result_has_referrer_metrics(self, sample_referral_settings):
+        result = run_pipeline(sample_referral_settings, skip_charts=True)
+        assert not result.referrer_metrics.empty
+        assert "Influence Score" in result.referrer_metrics.columns
+
+    def test_result_has_staff_metrics(self, sample_referral_settings):
+        result = run_pipeline(sample_referral_settings, skip_charts=True)
+        assert not result.staff_metrics.empty
+        assert "Multiplier Score" in result.staff_metrics.columns
+
+    def test_result_has_eight_analyses(self, sample_referral_settings):
+        result = run_pipeline(sample_referral_settings, skip_charts=True)
+        assert len(result.analyses) == 8
+
+    def test_no_analysis_errors(self, sample_referral_settings):
+        result = run_pipeline(sample_referral_settings, skip_charts=True)
+        for a in result.analyses:
+            assert a.error is None, f"{a.name} had error: {a.error}"
+
+    def test_skip_charts_produces_no_charts(self, sample_referral_settings):
+        result = run_pipeline(sample_referral_settings, skip_charts=True)
+        assert len(result.charts) == 0
+        assert len(result.chart_pngs) == 0
+
+    def test_progress_callback(self, sample_referral_settings):
+        calls = []
+
+        def on_progress(step, total, msg):
+            calls.append((step, total, msg))
+
+        run_pipeline(sample_referral_settings, on_progress=on_progress, skip_charts=True)
+        assert len(calls) >= 7  # At least 7 progress steps
+
+    def test_settings_preserved(self, sample_referral_settings):
+        result = run_pipeline(sample_referral_settings, skip_charts=True)
+        assert result.settings is sample_referral_settings
+
+
+class TestExportOutputs:
+    """Tests for export_outputs."""
+
+    def test_generates_excel_file(self, sample_referral_settings, tmp_path):
+        sample_referral_settings = sample_referral_settings.model_copy(
+            update={"output_dir": tmp_path / "out"}
+        )
+        result = run_pipeline(sample_referral_settings, skip_charts=True)
+        paths = export_outputs(result, skip_charts=True)
+        assert len(paths) >= 1
+        xlsx_paths = [p for p in paths if p.suffix == ".xlsx"]
+        assert len(xlsx_paths) == 1
+        assert xlsx_paths[0].exists()
+
+    def test_generates_pptx_file(self, sample_referral_settings, tmp_path):
+        sample_referral_settings = sample_referral_settings.model_copy(
+            update={"output_dir": tmp_path / "out"}
+        )
+        result = run_pipeline(sample_referral_settings, skip_charts=True)
+        paths = export_outputs(result, skip_charts=True)
+        pptx_paths = [p for p in paths if p.suffix == ".pptx"]
+        assert len(pptx_paths) == 1
+        assert pptx_paths[0].exists()
+
+    def test_output_dir_created(self, sample_referral_settings, tmp_path):
+        out_dir = tmp_path / "new_dir" / "sub"
+        sample_referral_settings = sample_referral_settings.model_copy(
+            update={"output_dir": out_dir}
+        )
+        result = run_pipeline(sample_referral_settings, skip_charts=True)
+        export_outputs(result, skip_charts=True)
+        assert out_dir.exists()
+
+    def test_filenames_contain_client_id(self, sample_referral_settings, tmp_path):
+        sample_referral_settings = sample_referral_settings.model_copy(
+            update={
+                "output_dir": tmp_path / "out",
+                "client_id": "1234",
+            }
+        )
+        result = run_pipeline(sample_referral_settings, skip_charts=True)
+        paths = export_outputs(result, skip_charts=True)
+        for p in paths:
+            assert "1234" in p.name

--- a/tests/referral/test_scoring.py
+++ b/tests/referral/test_scoring.py
@@ -1,0 +1,154 @@
+"""Tests for influence scoring and staff multiplier computation."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from ics_toolkit.referral.code_decoder import decode_referral_codes
+from ics_toolkit.referral.network import infer_networks
+from ics_toolkit.referral.normalizer import normalize_entities
+from ics_toolkit.referral.scoring import (
+    _safe_minmax,
+    compute_influence_scores,
+    compute_referrer_metrics,
+    compute_staff_multipliers,
+)
+from ics_toolkit.referral.temporal import add_temporal_signals
+from ics_toolkit.settings import ReferralSettings, ReferralScoringWeights, ReferralStaffWeights
+
+
+@pytest.fixture
+def settings():
+    return ReferralSettings()
+
+
+@pytest.fixture
+def enriched_df(sample_referral_df, settings):
+    """Full pipeline enrichment through layers 1-4."""
+    df = normalize_entities(sample_referral_df, settings)
+    df = decode_referral_codes(df, settings)
+    df = add_temporal_signals(df, settings)
+    df = infer_networks(df)
+    return df
+
+
+class TestSafeMinmax:
+    def test_normalizes_to_01(self):
+        s = pd.Series([1, 2, 3, 4, 5])
+        result = _safe_minmax(s)
+        assert result.min() == 0.0
+        assert result.max() == 1.0
+
+    def test_constant_series_returns_05(self):
+        s = pd.Series([5, 5, 5])
+        result = _safe_minmax(s)
+        assert (result == 0.5).all()
+
+    def test_single_value_returns_05(self):
+        s = pd.Series([42])
+        result = _safe_minmax(s)
+        assert result.iloc[0] == 0.5
+
+
+class TestComputeReferrerMetrics:
+    def test_returns_dataframe(self, enriched_df):
+        metrics = compute_referrer_metrics(enriched_df)
+        assert isinstance(metrics, pd.DataFrame)
+        assert len(metrics) > 0
+
+    def test_has_expected_columns(self, enriched_df):
+        metrics = compute_referrer_metrics(enriched_df)
+        expected = [
+            "Referrer", "total_referrals", "unique_accounts", "active_days",
+            "burst_count", "avg_days_between", "channels_used",
+        ]
+        for col in expected:
+            assert col in metrics.columns, f"Missing: {col}"
+
+    def test_excludes_unknown_referrer(self, enriched_df):
+        metrics = compute_referrer_metrics(enriched_df)
+        assert "UNKNOWN" not in metrics["Referrer"].values
+
+    def test_total_referrals_positive(self, enriched_df):
+        metrics = compute_referrer_metrics(enriched_df)
+        assert (metrics["total_referrals"] > 0).all()
+
+    def test_empty_input(self):
+        df = pd.DataFrame(columns=[
+            "Referrer", "New Account", "MRDB Account Hash", "Issue Date",
+            "Is Burst", "Days Since Last Referral", "Referral Channel",
+            "Branch Code", "Network ID", "Network Size",
+        ])
+        metrics = compute_referrer_metrics(df)
+        assert len(metrics) == 0
+
+
+class TestComputeInfluenceScores:
+    def test_adds_influence_score(self, enriched_df):
+        metrics = compute_referrer_metrics(enriched_df)
+        weights = ReferralScoringWeights()
+        scored = compute_influence_scores(metrics, weights)
+        assert "Influence Score" in scored.columns
+
+    def test_score_range_0_to_100(self, enriched_df):
+        metrics = compute_referrer_metrics(enriched_df)
+        weights = ReferralScoringWeights()
+        scored = compute_influence_scores(metrics, weights)
+        assert scored["Influence Score"].min() >= 0
+        assert scored["Influence Score"].max() <= 100
+
+    def test_repeat_referrers_score_higher(self, enriched_df):
+        metrics = compute_referrer_metrics(enriched_df)
+        weights = ReferralScoringWeights()
+        scored = compute_influence_scores(metrics, weights)
+        # Referrers with more unique accounts should generally score higher
+        top = scored.nlargest(3, "Influence Score")
+        bottom = scored.nsmallest(3, "Influence Score")
+        assert top["unique_accounts"].mean() >= bottom["unique_accounts"].mean()
+
+    def test_empty_metrics(self):
+        metrics = pd.DataFrame(columns=[
+            "Referrer", "unique_accounts", "burst_count", "channels_used",
+            "avg_days_between", "active_days",
+        ])
+        weights = ReferralScoringWeights()
+        scored = compute_influence_scores(metrics, weights)
+        assert "Influence Score" in scored.columns
+        assert len(scored) == 0
+
+
+class TestComputeStaffMultipliers:
+    def test_returns_dataframe(self, enriched_df, settings):
+        referrer_metrics = compute_referrer_metrics(enriched_df)
+        scored_metrics = compute_influence_scores(referrer_metrics, settings.scoring_weights)
+        staff = compute_staff_multipliers(enriched_df, scored_metrics, settings.staff_weights)
+        assert isinstance(staff, pd.DataFrame)
+        assert len(staff) > 0
+
+    def test_has_multiplier_score(self, enriched_df, settings):
+        referrer_metrics = compute_referrer_metrics(enriched_df)
+        scored_metrics = compute_influence_scores(referrer_metrics, settings.scoring_weights)
+        staff = compute_staff_multipliers(enriched_df, scored_metrics, settings.staff_weights)
+        assert "Multiplier Score" in staff.columns
+
+    def test_score_range_0_to_100(self, enriched_df, settings):
+        referrer_metrics = compute_referrer_metrics(enriched_df)
+        scored_metrics = compute_influence_scores(referrer_metrics, settings.scoring_weights)
+        staff = compute_staff_multipliers(enriched_df, scored_metrics, settings.staff_weights)
+        assert staff["Multiplier Score"].min() >= 0
+        assert staff["Multiplier Score"].max() <= 100
+
+    def test_excludes_unassigned(self, enriched_df, settings):
+        referrer_metrics = compute_referrer_metrics(enriched_df)
+        scored_metrics = compute_influence_scores(referrer_metrics, settings.scoring_weights)
+        staff = compute_staff_multipliers(enriched_df, scored_metrics, settings.staff_weights)
+        assert "UNASSIGNED" not in staff["Staff"].values
+
+    def test_empty_input(self, settings):
+        df = pd.DataFrame(columns=[
+            "Staff", "New Account", "Referrer", "Branch Code",
+        ])
+        metrics = pd.DataFrame(columns=["Referrer", "Influence Score"])
+        staff = compute_staff_multipliers(df, metrics, settings.staff_weights)
+        assert len(staff) == 0

--- a/tests/referral/test_settings.py
+++ b/tests/referral/test_settings.py
@@ -1,0 +1,150 @@
+"""Tests for referral settings models."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from ics_toolkit.settings import (
+    ReferralScoringWeights,
+    ReferralSettings,
+    ReferralStaffWeights,
+    Settings,
+)
+
+
+class TestReferralScoringWeights:
+    """Tests for influence score weight validation."""
+
+    def test_defaults_sum_to_one(self):
+        w = ReferralScoringWeights()
+        total = w.unique_accounts + w.burst_count + w.channels_used + w.velocity + w.longevity
+        assert abs(total - 1.0) < 1e-6
+
+    def test_accepts_valid_custom_weights(self):
+        w = ReferralScoringWeights(
+            unique_accounts=0.50,
+            burst_count=0.20,
+            channels_used=0.10,
+            velocity=0.10,
+            longevity=0.10,
+        )
+        assert w.unique_accounts == 0.50
+
+    def test_rejects_weights_not_summing_to_one(self):
+        with pytest.raises(ValidationError, match="sum to 1.0"):
+            ReferralScoringWeights(
+                unique_accounts=0.50,
+                burst_count=0.50,
+                channels_used=0.50,
+                velocity=0.10,
+                longevity=0.10,
+            )
+
+    def test_frozen(self):
+        w = ReferralScoringWeights()
+        with pytest.raises(ValidationError):
+            w.unique_accounts = 0.99
+
+    def test_rejects_extra_fields(self):
+        with pytest.raises(ValidationError):
+            ReferralScoringWeights(unknown_field=0.5)
+
+
+class TestReferralStaffWeights:
+    """Tests for staff multiplier weight validation."""
+
+    def test_defaults_sum_to_one(self):
+        w = ReferralStaffWeights()
+        total = w.avg_referrer_score + w.unique_referrers
+        assert abs(total - 1.0) < 1e-6
+
+    def test_rejects_bad_sum(self):
+        with pytest.raises(ValidationError, match="sum to 1.0"):
+            ReferralStaffWeights(avg_referrer_score=0.50, unique_referrers=0.60)
+
+
+class TestReferralSettings:
+    """Tests for the referral settings model."""
+
+    def test_defaults(self):
+        s = ReferralSettings()
+        assert s.data_file is None
+        assert s.burst_window_days == 14
+        assert s.dormancy_days == 180
+        assert s.top_n_referrers == 25
+        assert s.header_row == 0
+
+    def test_validates_data_file_exists(self, tmp_path):
+        path = tmp_path / "exists.xlsx"
+        path.touch()
+        s = ReferralSettings(data_file=path)
+        assert s.data_file == path
+
+    def test_rejects_missing_file(self, tmp_path):
+        path = tmp_path / "nope.xlsx"
+        with pytest.raises(ValidationError, match="not found"):
+            ReferralSettings(data_file=path)
+
+    def test_rejects_unsupported_format(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.touch()
+        with pytest.raises(ValidationError, match="Unsupported file type"):
+            ReferralSettings(data_file=path)
+
+    def test_derives_client_id_from_filename(self, tmp_path):
+        path = tmp_path / "1776_referral.xlsx"
+        path.touch()
+        s = ReferralSettings(data_file=path)
+        assert s.client_id == "1776"
+        assert s.client_name == "Client 1776"
+
+    def test_client_id_unknown_for_non_numeric(self, tmp_path):
+        path = tmp_path / "referral_data.xlsx"
+        path.touch()
+        s = ReferralSettings(data_file=path)
+        assert s.client_id == "unknown"
+
+    def test_code_prefix_map_defaults(self):
+        s = ReferralSettings()
+        assert "150A" in s.code_prefix_map
+        assert s.code_prefix_map["150A"] == "BRANCH_STANDARD"
+        assert s.code_prefix_map["PC"] == "DIGITAL_PROCESS"
+
+    def test_rejects_extra_fields(self):
+        with pytest.raises(ValidationError):
+            ReferralSettings(bogus_field=True)
+
+
+class TestSettingsIntegration:
+    """Tests for referral settings within the unified Settings model."""
+
+    def test_settings_has_referral_key(self):
+        s = Settings()
+        assert isinstance(s.referral, ReferralSettings)
+
+    def test_for_referral_factory(self, tmp_path):
+        path = tmp_path / "1776_test.xlsx"
+        path.touch()
+        s = Settings.for_referral(data_file=path)
+        assert s.referral.data_file == path
+        assert s.referral.client_id == "1776"
+
+    def test_from_yaml_with_referral(self, tmp_path):
+        config = tmp_path / "config.yaml"
+        config.write_text(
+            "referral:\n"
+            "  burst_window_days: 21\n"
+            "  top_n_referrers: 10\n"
+        )
+        s = Settings.from_yaml(config_path=config)
+        assert s.referral.burst_window_days == 21
+        assert s.referral.top_n_referrers == 10
+
+    def test_existing_settings_unaffected(self):
+        s = Settings()
+        assert hasattr(s, "append")
+        assert hasattr(s, "analysis")
+        assert hasattr(s, "referral")

--- a/tests/referral/test_temporal.py
+++ b/tests/referral/test_temporal.py
@@ -1,0 +1,69 @@
+"""Tests for temporal signal analysis."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from ics_toolkit.referral.normalizer import normalize_entities
+from ics_toolkit.referral.code_decoder import decode_referral_codes
+from ics_toolkit.referral.temporal import add_temporal_signals
+from ics_toolkit.settings import ReferralSettings
+
+
+@pytest.fixture
+def settings():
+    return ReferralSettings()
+
+
+@pytest.fixture
+def enriched_df(sample_referral_df, settings):
+    """Sample df with normalization and decoding applied."""
+    df = normalize_entities(sample_referral_df, settings)
+    df = decode_referral_codes(df, settings)
+    return df
+
+
+class TestAddTemporalSignals:
+    def test_adds_expected_columns(self, enriched_df, settings):
+        result = add_temporal_signals(enriched_df, settings)
+        expected = ["Days Since Last Referral", "Is Burst", "Days Since Latest", "Is New Referrer"]
+        for col in expected:
+            assert col in result.columns, f"Missing: {col}"
+
+    def test_first_referral_per_referrer_has_null_gap(self, enriched_df, settings):
+        result = add_temporal_signals(enriched_df, settings)
+        for referrer, group in result.groupby("Referrer"):
+            first_idx = group.index[0]
+            assert pd.isna(result.loc[first_idx, "Days Since Last Referral"])
+
+    def test_is_burst_boolean(self, enriched_df, settings):
+        result = add_temporal_signals(enriched_df, settings)
+        assert result["Is Burst"].dtype == bool
+
+    def test_days_since_latest_non_negative(self, enriched_df, settings):
+        result = add_temporal_signals(enriched_df, settings)
+        valid = result["Days Since Latest"].dropna()
+        assert (valid >= 0).all()
+
+    def test_burst_window_configurable(self, enriched_df):
+        short_window = ReferralSettings(burst_window_days=3)
+        wide_window = ReferralSettings(burst_window_days=365)
+        short = add_temporal_signals(enriched_df, short_window)
+        wide = add_temporal_signals(enriched_df, wide_window)
+        assert short["Is Burst"].sum() <= wide["Is Burst"].sum()
+
+    def test_is_new_referrer_reflects_lookback(self, enriched_df):
+        # With a very long lookback, all referrers should be "new"
+        long_lookback = ReferralSettings(emerging_lookback_days=9999)
+        result = add_temporal_signals(enriched_df, long_lookback)
+        assert result["Is New Referrer"].all()
+
+    def test_handles_all_nat_dates(self, settings):
+        df = pd.DataFrame({
+            "Referrer": ["A", "B"],
+            "Issue Date": [pd.NaT, pd.NaT],
+            "Referral Channel": ["X", "Y"],
+        })
+        result = add_temporal_signals(df, settings)
+        assert "Days Since Last Referral" in result.columns


### PR DESCRIPTION
## Summary
- New `referral` CLI subcommand and pipeline that ingests referral tracking files (.xls/.xlsx/.csv) and produces 8 analysis artifacts with influence scoring, network inference, and staff multiplier reports
- 28 source modules across 5 layers: data loading, entity normalization, code decoding, temporal signals, network inference, influence scoring, 8 analysis artifacts (R01-R08), 5 Plotly charts, and Excel/PPTX exports
- 212 new tests (1044 total), zero regressions, lint clean

### Architecture
| Layer | Module | Purpose |
|-------|--------|---------|
| Foundation | `settings`, `cli`, `column_map`, `data_loader` | Config (Pydantic), CLI command, column aliases, file loading (.xls/.xlsx/.csv) |
| Core Engine | `normalizer`, `code_decoder`, `temporal`, `network`, `scoring` | Entity normalization, prefix-based code classification, burst/recency signals, surname-based network inference, weighted influence scoring (0-100) |
| Analyses | R01-R08 | Top Referrers, Emerging, Dormant High-Value, One-time vs Repeat, Staff Multipliers, Branch Density, Code Health, Overview KPIs |
| Charts | 5 builders | Horizontal bar, scatter timeline, grouped bar, vertical bar, stacked bar |
| Exports | `pipeline`, `excel`, `pptx` | Orchestration, formatted Excel with chart images, sectioned PPTX presentation |

### Usage
```bash
python -m ics_toolkit referral data/referral_file.xls
python -m ics_toolkit referral data/file.xlsx --client-id 1776 --no-charts
```

## Test plan
- [x] 212 referral tests passing (data loader, normalizer, code decoder, temporal, network, scoring, 8 analyses, charts, pipeline, exports)
- [x] 1044 total tests passing -- zero regressions on existing `analyze` and `append` commands
- [x] `ruff check` + `ruff format` clean
- [x] End-to-end pipeline test: load -> enrich -> analyze -> export Excel + PPTX

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)